### PR TITLE
Fix garbage collection performance bug when migrating chares

### DIFF
--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -525,7 +525,14 @@ class Charm(object):
         obj = self.arrays[aid].pop(index)
         self.threadMgr.objMigrating(obj)
         del obj._contributeInfo  # don't want to pickle this
-        return cPickle.dumps(({}, obj), Options.PICKLE_PROTOCOL)
+        pickled_chare = cPickle.dumps(({}, obj), Options.PICKLE_PROTOCOL)
+        # facilitate garbage collection (especially by removing cyclical references)
+        del obj._local
+        del obj._local_free_head
+        del obj._active_grp_conds
+        obj._cond_next = None
+        obj._cond_last = None
+        return pickled_chare
 
     # Charm class level contribute function used by Array, Group for reductions
     def contribute(self, data, reducer, target, contributor):


### PR DESCRIPTION
Although Python's garbage collector could correctly delete
migrated chares, the presence of cyclical references in some of
the internal members of Chare meant that it could only do
so periodically, using an expensive garbage collection routine.

This patch can thus significantly speed up the process by manually
removing the cyclical references after a chare migrates.