### PR TITLE
charmlib layer: rename CreateReductionTargetMsg functions

### DIFF
--- a/charm4py/charmlib/ccharm.pxd
+++ b/charm4py/charmlib/ccharm.pxd
@@ -52,7 +52,7 @@ cdef extern from "charm.h":
     void registerArrayElemLeaveExtCallback(int (*cb)(int, int, int *, char**, int));
     void registerArrayElemJoinExtCallback(void (*cb)(int, int, int *, int, char*, int));
     void registerArrayResumeFromSyncExtCallback(void (*cb)(int, int, int *));
-    void registerCreateReductionTargetMsgExtCallback(void (*cb)(void*, int, int, int, char**, int*));
+    void registerCreateCallbackMsgExtCallback(void (*cb)(void*, int, int, int, char**, int*));
     void registerPyReductionExtCallback(int (*cb)(char**, int*, int, char**));
     void registerArrayMapProcNumExtCallback(int (*cb)(int, int, const int *));
 

--- a/charm4py/charmlib/charmlib_cffi.py
+++ b/charm4py/charmlib/charmlib_cffi.py
@@ -430,7 +430,7 @@ class CharmLib(object):
     lib.CkExtContributeToArray(contributeInfo.data, aid, index, len(index))
 
   @ffi.def_extern()
-  def createReductionTargetMsg_py2(data, dataSize, reducerType, fid, returnBuffers, returnBufferSizes):
+  def createCallbackMsg_py2(data, dataSize, reducerType, fid, returnBuffers, returnBufferSizes):
     try:
       if charm.opts.PROFILING: t0 = time.time()
 
@@ -484,7 +484,7 @@ class CharmLib(object):
       charm.handleGeneralError()
 
   @ffi.def_extern()
-  def createReductionTargetMsg_py3(data, dataSize, reducerType, fid, returnBuffers, returnBufferSizes):
+  def createCallbackMsg_py3(data, dataSize, reducerType, fid, returnBuffers, returnBufferSizes):
     try:
       if charm.opts.PROFILING: t0 = time.time()
 
@@ -629,7 +629,7 @@ class CharmLib(object):
       lib.registerArrayMsgRecvExtCallback(lib.recvArrayMsg_py2)
       lib.registerArrayElemJoinExtCallback(lib.arrayElemJoin_py2)
       lib.registerPyReductionExtCallback(lib.pyReduction_py2)
-      lib.registerCreateReductionTargetMsgExtCallback(lib.createReductionTargetMsg_py2)
+      lib.registerCreateCallbackMsgExtCallback(lib.createCallbackMsg_py2)
     else:
       lib.registerReadOnlyRecvExtCallback(lib.recvReadOnly_py3)
       lib.registerChareMsgRecvExtCallback(lib.recvChareMsg_py3)
@@ -637,7 +637,7 @@ class CharmLib(object):
       lib.registerArrayMsgRecvExtCallback(lib.recvArrayMsg_py3)
       lib.registerArrayElemJoinExtCallback(lib.arrayElemJoin_py3)
       lib.registerPyReductionExtCallback(lib.pyReduction_py3)
-      lib.registerCreateReductionTargetMsgExtCallback(lib.createReductionTargetMsg_py3)
+      lib.registerCreateCallbackMsgExtCallback(lib.createCallbackMsg_py3)
 
     self.CkArrayExtSend = lib.CkArrayExtSend
     self.CkGroupExtSend = lib.CkGroupExtSend

--- a/charm4py/charmlib/charmlib_cffi_build.py
+++ b/charm4py/charmlib/charmlib_cffi_build.py
@@ -225,7 +225,7 @@ ffibuilder.cdef("""
     void registerArrayElemLeaveExtCallback(int (*cb)(int, int, int *, char**, int));
     void registerArrayElemJoinExtCallback(void (*cb)(int, int, int *, int, char*, int));
     void registerArrayResumeFromSyncExtCallback(void (*cb)(int, int, int *));
-    void registerCreateReductionTargetMsgExtCallback(void (*cb)(void*, int, int, int, char**, int*));
+    void registerCreateCallbackMsgExtCallback(void (*cb)(void*, int, int, int, char**, int*));
     void registerPyReductionExtCallback(int (*cb)(char**, int*, int, char**));
     void registerArrayMapProcNumExtCallback(int (*cb)(int, int, const int *));
 
@@ -248,8 +248,8 @@ ffibuilder.cdef("""
     extern "Python" void arrayElemJoin_py2(int, int, int *, int, char*, int);
     extern "Python" void arrayElemJoin_py3(int, int, int *, int, char*, int);
     extern "Python" void resumeFromSync(int, int, int *);
-    extern "Python" void createReductionTargetMsg_py2(void*, int, int, int, char**, int*);
-    extern "Python" void createReductionTargetMsg_py3(void*, int, int, int, char**, int*);
+    extern "Python" void createCallbackMsg_py2(void*, int, int, int, char**, int*);
+    extern "Python" void createCallbackMsg_py3(void*, int, int, int, char**, int*);
     extern "Python" int pyReduction_py2(char**, int*, int, char**);
     extern "Python" int pyReduction_py3(char**, int*, int, char**);
     extern "Python" int arrayMapProcNum(int, int, const int*);

--- a/charm4py/charmlib/charmlib_ctypes.py
+++ b/charm4py/charmlib/charmlib_ctypes.py
@@ -414,7 +414,7 @@ class CharmLib(object):
     c_elemIdx = (ctypes.c_int * ndims)(*index)
     self.lib.CkExtContributeToArray(ctypes.byref(contributeInfo), aid, c_elemIdx, ndims)
 
-  def createReductionTargetMsg(self, data, dataSize, reducerType, fid, returnBuffers, returnBufferSizes):
+  def createCallbackMsg(self, data, dataSize, reducerType, fid, returnBuffers, returnBufferSizes):
     try:
       if self.opts.PROFILING: t0 = time.time()
 
@@ -579,10 +579,10 @@ class CharmLib(object):
     self.resumeFromSyncCb = self.RESUME_FROM_SYNC_CB_TYPE(self.resumeFromSync)
     self.lib.registerArrayResumeFromSyncExtCallback(self.resumeFromSyncCb)
 
-    # Args to createReductionTargetMsg: data, return_buffer, data_size, reducer_type
+    # Args to createCallbackMsg: data, return_buffer, data_size, reducer_type
     self.CREATE_RED_TARG_MSG_CB_TYPE = CFUNCTYPE(None, c_void_p, c_int, c_int, c_int, POINTER(c_char_p), POINTER(c_int))
-    self.createReductionTargetMsgCb = self.CREATE_RED_TARG_MSG_CB_TYPE(self.createReductionTargetMsg)
-    self.lib.registerCreateReductionTargetMsgExtCallback(self.createReductionTargetMsgCb)
+    self.createCallbackMsgCb = self.CREATE_RED_TARG_MSG_CB_TYPE(self.createCallbackMsg)
+    self.lib.registerCreateCallbackMsgExtCallback(self.createCallbackMsgCb)
 
     # Args to pyReduction: msgs, msgSizes, nMsgs, returnBuffer
     self.PY_REDUCTION_CB_TYPE = CFUNCTYPE(c_int, POINTER(c_void_p), POINTER(c_int), c_int, POINTER(c_char_p))

--- a/charm4py/charmlib/charmlib_cython.pyx
+++ b/charm4py/charmlib/charmlib_cython.pyx
@@ -637,7 +637,7 @@ class CharmLib(object):
     registerArrayMapProcNumExtCallback(arrayMapProcNum)
     registerArrayElemJoinExtCallback(arrayElemJoin)
     registerPyReductionExtCallback(pyReduction)
-    registerCreateReductionTargetMsgExtCallback(createReductionTargetMsg)
+    registerCreateCallbackMsgExtCallback(createCallbackMsg)
 
   def CkMyPe(self): return CkMyPeHook()
   def CkNumPes(self): return CkNumPesHook()
@@ -834,7 +834,7 @@ cdef void resumeFromSync(int aid, int ndims, int *arrayIndex):
   except:
     charm.handleGeneralError()
 
-cdef void createReductionTargetMsg(void *data, int dataSize, int reducerType, int fid, char **returnBuffers, int *returnBufferSizes):
+cdef void createCallbackMsg(void *data, int dataSize, int reducerType, int fid, char **returnBuffers, int *returnBufferSizes):
   cdef int numElems
   cdef array.array a
   cdef int item_size


### PR DESCRIPTION
They are renamed to CreateCallbackMsg and similar names. This is
to account for the more general purpose of these functions and
the new name in the Charm++ C API.

These functions are called from Charm++ to obtain charm4py
messages directed toward charm4py callbacks.