### PR TITLE
Added Chare.setMigratable(bool) to indicate migratable status

### DIFF
--- a/charm4py/chare.py
+++ b/charm4py/chare.py
@@ -128,6 +128,10 @@ class Chare(object):
     def migrated(self):
         pass
 
+    def setMigratable(self, migratable):
+        charm.lib.setMigratable(self.thisProxy.aid, self.thisIndex, migratable)
+        self.migratable = migratable
+
     # deposit value of one of the futures that was created by this chare
     def _future_deposit_result(self, fid, result=None):
         charm.threadMgr.depositFuture(fid, result)
@@ -152,7 +156,7 @@ method_restrictions = {
     # reserved methods are those that can't be redefined in user subclass
     'reserved': {'__addLocal__', '__removeLocal__', '__flush_wait_queues__',
                  '__waitEnqueue__', 'wait', 'contribute', 'AtSync',
-                 'migrate', '_future_deposit_result',
+                 'migrate', 'setMigratable', '_future_deposit_result',
                  '_coll_future_deposit_result', '__getRedNo__',
                  '__addThreadEventSubscriber__'},
 
@@ -450,6 +454,7 @@ class Array(object):
         # NOTE currently only used at Python level. proxy object in charm runtime currently has this set to true
         obj.usesAtSync = False
         obj._contributeInfo = charm.lib.initContributeInfo(aid, obj.thisIndex, CONTRIBUTOR_TYPE_ARRAY)
+        obj.migratable = True
 
     @classmethod
     def __baseEntryMethods__(cls):

--- a/charm4py/charmlib/ccharm.pxd
+++ b/charm4py/charmlib/ccharm.pxd
@@ -42,6 +42,7 @@ cdef extern from "charm.h":
 
     int CkGroupGetReductionNumber(int gid);
     int CkArrayGetReductionNumber(int aid, int ndims, int *index);
+    void CkSetMigratable(int aid, int ndims, int *index, char migratable);
 
     void registerCkRegisterMainModuleCallback(void (*cb)());
     void registerMainchareCtorExtCallback(void (*cb)(int, void*, int, int, char **));

--- a/charm4py/charmlib/charmlib_cffi.py
+++ b/charm4py/charmlib/charmlib_cffi.py
@@ -320,6 +320,9 @@ class CharmLib(object):
   def getArrayElementRedNo(self, aid, index):
     return lib.CkArrayGetReductionNumber(aid, len(index), index)
 
+  def setMigratable(self, aid, index, migratable):
+    lib.CkSetMigratable(aid, len(index), index, ffi.cast('char', migratable))
+
   def getTopoTreeEdges(self, pe, root_pe, pes, bfactor):
     parent       = ffi.new('int*')
     child_count  = ffi.new('int*')

--- a/charm4py/charmlib/charmlib_cffi_build.py
+++ b/charm4py/charmlib/charmlib_cffi_build.py
@@ -215,6 +215,7 @@ ffibuilder.cdef("""
 
     int CkGroupGetReductionNumber(int gid);
     int CkArrayGetReductionNumber(int aid, int ndims, int *index);
+    void CkSetMigratable(int aid, int ndims, int *index, char migratable);
 
     void registerCkRegisterMainModuleCallback(void (*cb)());
     void registerMainchareCtorExtCallback(void (*cb)(int, void*, int, int, char **));

--- a/charm4py/charmlib/charmlib_ctypes.py
+++ b/charm4py/charmlib/charmlib_ctypes.py
@@ -310,6 +310,11 @@ class CharmLib(object):
     c_index = (c_int*indexDims)(*index)
     return self.lib.CkArrayGetReductionNumber(aid, indexDims, c_index)
 
+  def setMigratable(self, aid, index, migratable):
+    ndims = len(index)
+    c_index = (c_int*ndims)(*index)
+    self.lib.CkSetMigratable(aid, ndims, c_index, migratable)
+
   def getTopoTreeEdges(self, pe, root_pe, pes, bfactor):
     parent       = c_int(0)
     child_count  = c_int(0)

--- a/charm4py/charmlib/charmlib_cython.pyx
+++ b/charm4py/charmlib/charmlib_cython.pyx
@@ -517,6 +517,12 @@ class CharmLib(object):
     for i in range(ndims): c_index[i] = index[i]
     return CkArrayGetReductionNumber(aid, ndims, c_index)
 
+  def setMigratable(self, int aid, index not None, char migratable):
+    cdef int ndims = len(index)
+    cdef int i = 0
+    for i in range(ndims): c_index[i] = index[i]
+    CkSetMigratable(aid, ndims, c_index, migratable)
+
   def getTopoTreeEdges(self, int pe, int root_pe, pes, int bfactor):
     cdef int parent
     cdef int child_count

--- a/test_config.json
+++ b/test_config.json
@@ -82,6 +82,9 @@
         "args": "+balancer GreedyRefineLB +LBDebug 1"
     },
     {
+        "path": "tests/migration/test_nonmigratables.py"
+    },
+    {
         "force_min_processes": 4,
         "path": "tests/migration/chare_migration.py"
     },

--- a/tests/migration/test_nonmigratables.py
+++ b/tests/migration/test_nonmigratables.py
@@ -1,0 +1,41 @@
+from charm4py import charm, Chare, Array
+import sys
+sys.argv += ['+balancer', 'RandCentLB', '+LBPeriod', '0.001']
+
+MAX_ITER = 100
+
+
+class Test(Chare):
+
+    def __init__(self):
+        self.iteration = 0
+        self.originalPe = charm.myPe()
+        if self.thisIndex[0] % 2 == 0:
+            self.setMigratable(False)
+
+    def start(self):
+        self.hasMigrated = False
+        self.iteration += 1
+        if self.iteration == MAX_ITER:
+            self.contribute(None, None, charm.thisProxy[0].exit)
+        else:
+            self.prevPe = charm.myPe()
+            self.AtSync()
+
+    def resumeFromSync(self):
+        assert self.migratable == (self.thisIndex[0] % 2 != 0)
+        if not self.migratable:
+            assert charm.myPe() == self.originalPe
+        assert self.hasMigrated == (self.prevPe != charm.myPe())
+        self.thisProxy[self.thisIndex].start()
+
+    def migrated(self):
+        self.hasMigrated = True
+
+
+def main(args):
+    array = Array(Test, charm.numPes() * 8, useAtSync=True)
+    array.start()
+
+
+charm.start(main)


### PR DESCRIPTION
Chares that are part of Arrays are migratable by default. If set
to non-migratable status with setMigratable(False), this indicates
to the Charm++ load balancing framework that they shouldn't be
migrated.