### PR TITLE
Add charm.addReducer entry method

### DIFF
--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -741,6 +741,9 @@ class Charm(object):
     def abort(self, msg):
         self.lib.CkAbort(msg)
 
+    def addReducer(self, func):
+        self.reducers.addReducer(func)
+
     def LBTurnInstrumentOn(self):
         self.lib.LBTurnInstrumentOn()
 
@@ -766,6 +769,9 @@ class CharmRemote(Chare):
 
     def myPe(self):
         return charm.myPe()
+
+    def addReducer(self, func):
+        charm.addReducer(func)
 
     # user signature is: `def updateGlobals(self, global_dict, module_name='__main__')`
     def updateGlobals(self, *args):


### PR DESCRIPTION
This allows adding new custom reducers after charm has started,
for example:

charm.thisProxy.exec('def myreducer(contribs): return None',
                     ret=1).get()
charm.thisProxy.addReducer(myreducer, ret=1).get()