### PR TITLE
Fix travis build by removing depth restriction on git clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: cpp
 os: linux
 dist: xenial
+git:
+  depth: false
 cache: ccache
 before_install:
   - sudo apt-get install python-dev


### PR DESCRIPTION
The setup.py script needs to determine the version of charm4py by
doing git describe, and a limited clone depth can cause git
describe to fail.