### PR TITLE
Remove CkMyPe, CkNumPes, CkExit, CkAbort globals

### DIFF
--- a/charm4py/__init__.py
+++ b/charm4py/__init__.py
@@ -20,11 +20,6 @@ if os.environ.get('CHARM_NOLOAD', '0') == '0':
     from .charm import charm, readonlies, Options
     Reducer = charm.reducers
 
-    CkMyPe = charm.myPe
-    CkNumPes = charm.numPes
-    CkExit = charm.exit
-    CkAbort = charm.abort
-
     from .entry_method import when, threaded, threaded_ext
 
     from .chare import Chare, Group, Array, ArrayMap


### PR DESCRIPTION
These have been deprecated for a while, in favor of charm.myPe(),
charm.numPes(), exit() and charm.abort()