### PR TITLE
Change allreduce API

### DIFF
--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -641,14 +641,6 @@ class Charm(object):
             self.recordSend(contributeInfo.getDataSize())
         target.__self__.ckContribute(contributeInfo)
 
-    def allReduce(self, data, reducer, contributor):
-        collective_future = self.threadMgr.createCollectiveFuture(contributor.__getRedNo__())
-        self.contribute(data, reducer, collective_future, contributor)
-        return collective_future.get()  # blocks until result of reduction comes
-
-    def barrier(self, contributor):
-        self.allReduce(None, None, contributor)
-
     def startQD(self, callback):
         fid = 0
         if isinstance(callback, Future):

--- a/tests/reductions/allreduce.py
+++ b/tests/reductions/allreduce.py
@@ -11,7 +11,7 @@ class Test(Chare):
             index = self.thisIndex
         i = 137
         for _ in range(1000):
-            result = charm.allReduce(index + i, Reducer.sum, self)
+            result = self.allreduce(index + i, Reducer.sum).get()
             expected = float(numChares) * (numChares - 1) / 2 + (i * numChares)
             assert result == expected
             i += 1


### PR DESCRIPTION
allreduce is now a method of Chare, and has the same signature as
Chare.reduce(), except that a callback is not needed since all the
chares that call allreduce will get a result.

Also, made allreduce non-blocking by returning a future.

Removed charm.barrier(chare) because the same can be achieved
by doing empty allreduce: self.allreduce().get()