### PR TITLE
Don't modify header in Charm.process_em_exec()

### DIFF
--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -158,9 +158,8 @@ class Charm(object):
     def process_em_exc(self, e, obj, header):
         if b'block' not in header:
             raise e
-        else:
-            # remote is expecting a response via a future, send exception to the future
-            blockFuture = header[b'block']
+        # remote is expecting a response via a future, send exception to the future
+        blockFuture = header[b'block']
         if b'creation' in header:
             # don't send anything in this case (future is not guaranteed to be used)
             obj.contribute(None, None, blockFuture)

--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -158,8 +158,9 @@ class Charm(object):
     def process_em_exc(self, e, obj, header):
         if b'block' not in header:
             raise e
-        # remote is expecting a response via a future, send exception to the future
-        blockFuture = header.pop(b'block')
+        else:
+            # remote is expecting a response via a future, send exception to the future
+            blockFuture = header[b'block']
         if b'creation' in header:
             # don't send anything in this case (future is not guaranteed to be used)
             obj.contribute(None, None, blockFuture)

--- a/charm4py/entry_method.py
+++ b/charm4py/entry_method.py
@@ -49,6 +49,7 @@ class EntryMethod(object):
             charm.exit(exit_code)
         except Exception as e:
             charm.process_em_exc(e, obj, header)
+            return
         if b'block' in header:
             blockFuture = header[b'block']
             if b'bcast' in header:

--- a/charm4py/threads.py
+++ b/charm4py/threads.py
@@ -178,13 +178,10 @@ class EntryMethodThreadManager(object):
                         ret = getattr(obj, entry_method.name)(*args)  # invoke entry method
                         if b'block' in header:
                             if b'bcast' in header:
-                                sid = None
-                                if b'sid' in header:
-                                    sid = header[b'sid']
                                 if b'bcastret' in header:
-                                    obj.contribute(ret, charm.reducers.gather, header[b'block'], sid)
+                                    obj.contribute(ret, charm.reducers.gather, header[b'block'])
                                 else:
-                                    obj.contribute(None, None, header[b'block'], sid)
+                                    obj.contribute(None, None, header[b'block'])
                             else:
                                 header[b'block'].send(ret)
                     except Exception as e:


### PR DESCRIPTION
The msg header should be readonly, to in the future allow passing
the same msg header and arguments (same Python objects) to
multiple local chares in a broadcast or section multicast.