### PR TITLE
Fix object wait condition queues not being flushed after future resumed

### DIFF
--- a/test_config.json
+++ b/test_config.json
@@ -52,6 +52,10 @@
         "path": "tests/when/when_test2.py"
     },
     {
+        "force_min_processes": 4,
+        "path": "tests/when/stencil.py"
+    },
+    {
         "path": "tests/reductions/group_reduction.py"
     },
     {

--- a/tests/when/stencil.py
+++ b/tests/when/stencil.py
@@ -1,0 +1,46 @@
+from charm4py import charm, Chare, Array, threaded, when
+
+
+NUM_ITER = 500
+CHARES_PER_PE = 8
+
+
+class Cell(Chare):
+
+    def __init__(self, numChares):
+        idx = self.thisIndex[0]
+        self.nbs = []
+        for i in range(1, 4):
+            self.nbs.append(self.thisProxy[(idx + i) % numChares])
+            self.nbs.append(self.thisProxy[(idx - i) % numChares])
+        self.msgs_recvd = 0
+
+    @threaded
+    def work(self, done_fut):
+        self.iter_complete = charm.createFuture()
+        for self.iteration in range(NUM_ITER):
+            for nb in self.nbs:
+                nb.recvData(self.iteration, None)
+            self.iter_complete = charm.createFuture()
+            self.iter_complete.get()
+        self.reduce(done_fut)
+
+    @when('self.iteration == iteration')
+    def recvData(self, iteration, data):
+        self.msgs_recvd += 1
+        if self.msgs_recvd == len(self.nbs):
+            self.msgs_recvd = 0
+            self.iter_complete()
+
+
+def main(args):
+    numChares = charm.numPes() * CHARES_PER_PE
+    cells = Array(Cell, numChares, args=[numChares])
+    charm.awaitCreation(cells)
+    f = charm.createFuture()
+    cells.work(f)
+    f.get()
+    exit()
+
+
+charm.start(main)


### PR DESCRIPTION
Previously, the value of a future was deposited from an entry method
of the object to which the future belongs. So the wait queues were
automatically flushed after the resumed thread finishes/pauses.

But after the change that sends futures to CharmRemote, the value
is now deposited from an entry method of CharmRemote, and the wait
queues are not flushed automatically. So we do it manually after
the resumed thread finishes/pauses.