### PR TITLE
Keep reference to libmpi when running with OpenMPI

### DIFF
--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -108,7 +108,7 @@ class Charm(object):
             # this is needed for OpenMPI, see:
             # https://svn.open-mpi.org/trac/ompi/wiki/Linkers
             import ctypes
-            ctypes.CDLL('libmpi.so', mode=ctypes.RTLD_GLOBAL)
+            self.__libmpi__ = ctypes.CDLL('libmpi.so', mode=ctypes.RTLD_GLOBAL)
         self.lib = load_charm_library(self)
         self.ReducerType = self.lib.ReducerType
         self.CkContributeToChare = self.lib.CkContributeToChare


### PR DESCRIPTION
When running Charm4py with MPI comm layer and OpenMPI, we need to
explicitly open libmpi with RTLD_GLOBAL (see dc36dfe). In addition,
when running with PyPy, we need to keep a reference to the opened
library.