### PR TITLE
Use incremental future IDs instead of pool, for better error detection

### DIFF
--- a/charm4py/threads.py
+++ b/charm4py/threads.py
@@ -2,6 +2,9 @@ import array
 from greenlet import getcurrent
 
 
+# Future IDs (fids) are sometimes carried as reference numbers inside
+# Charm++ CkCallback objects. The data type most commonly used for
+# this is unsigned short, hence this limit
 FIDMAXVAL = 65535
 
 
@@ -103,7 +106,7 @@ class EntryMethodThreadManager(object):
         self.options = charm.options
         # pool of Future IDs for futures created by this ThreadManager. Can
         # have as many active futures as the size of this pool
-        self.lastfid = 0
+        self.lastfid = 0  # future ID of the last future created on this PE
         self.futures = {}  # future ID -> Future object
         self.coll_futures = {}  # (future ID, obj) -> CollectiveFuture object
 

--- a/charm4py/threads.py
+++ b/charm4py/threads.py
@@ -2,6 +2,9 @@ import array
 from greenlet import getcurrent
 
 
+FIDMAXVAL = 65535
+
+
 class NotThreadedError(Exception):
     def __init__(self, msg):
         super(NotThreadedError, self).__init__(msg)
@@ -100,7 +103,7 @@ class EntryMethodThreadManager(object):
         self.options = charm.options
         # pool of Future IDs for futures created by this ThreadManager. Can
         # have as many active futures as the size of this pool
-        self.fidpool = array.array('H', range(30000, 0, -1))
+        self.lastfid = 0
         self.futures = {}  # future ID -> Future object
         self.coll_futures = {}  # (future ID, obj) -> CollectiveFuture object
 
@@ -174,9 +177,16 @@ class EntryMethodThreadManager(object):
         gr = getcurrent()
         if gr == self.main_gr:
             self.throwNotThreadedError()
-        fid = self.fidpool.pop()  # get a unique local Future ID from pool
+        # get a unique local Future ID
+        global FIDMAXVAL
+        futures = self.futures
+        assert len(futures) < FIDMAXVAL, 'Too many pending futures, cannot create more'
+        fid = (self.lastfid % FIDMAXVAL) + 1
+        while fid in futures:
+            fid = (fid % FIDMAXVAL) + 1
+        self.lastfid = fid
         f = Future(fid, gr, charm._myPe, num_vals)
-        self.futures[fid] = f
+        futures[fid] = f
         return f
 
     def createCollectiveFuture(self, fid, obj, proxy):
@@ -193,7 +203,6 @@ class EntryMethodThreadManager(object):
         f = self.futures[fid]
         if f.deposit(result):
             del self.futures[fid]
-            self.fidpool.append(fid)
             # resume if a thread is blocked on the future
             obj = f.gr.obj
             f.resume(self)
@@ -212,7 +221,6 @@ class EntryMethodThreadManager(object):
     def cancelFuture(self, f):
         fid = f.fid
         del self.futures[fid]
-        self.fidpool.append(fid)
         f.gotvalues = True
         f.values = [None] * f.nvals
         f.resume(self)

--- a/charm4py/threads.py
+++ b/charm4py/threads.py
@@ -104,8 +104,6 @@ class EntryMethodThreadManager(object):
         charm = _charm
         threadMgr = self
         self.options = charm.options
-        # pool of Future IDs for futures created by this ThreadManager. Can
-        # have as many active futures as the size of this pool
         self.lastfid = 0  # future ID of the last future created on this PE
         self.futures = {}  # future ID -> Future object
         self.coll_futures = {}  # (future ID, obj) -> CollectiveFuture object


### PR DESCRIPTION
There are some future-related errors that can be hard to detect.
For example, attempting to reuse futures by sending values to a
future that already received them. If new futures immediately
reuse old future IDs (fid), this can end up sending the value to
a new future, which can lead to weird application errors or
deadlocks.

Instead, this patch gives incremental fids to futures created
on the same PE. When the limit is reached (currently 65535 because
Charm++ normally uses unsigned short for reference numbers carried
in callbacks) it restarts at 1. As such, resending to a used
future will almost certainly trigger a future not found error
instead.

Also, there is no pool so it uses less memory.