### PR TITLE
Renamed @threaded to @coro

### DIFF
--- a/charm4py/__init__.py
+++ b/charm4py/__init__.py
@@ -21,7 +21,7 @@ if os.environ.get('CHARM_NOLOAD', '0') == '0':
     Reducer = charm.reducers
     Future = charm.createFuture
 
-    from .entry_method import when, coro, coro_ext, threaded
+    from .entry_method import when, coro, coro_ext, coro as threaded
 
     from .chare import Chare, Group, Array, ArrayMap
 

--- a/charm4py/__init__.py
+++ b/charm4py/__init__.py
@@ -21,7 +21,7 @@ if os.environ.get('CHARM_NOLOAD', '0') == '0':
     Reducer = charm.reducers
     Future = charm.createFuture
 
-    from .entry_method import when, threaded, threaded_ext
+    from .entry_method import when, coro, coro_ext, threaded
 
     from .chare import Chare, Group, Array, ArrayMap
 

--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -465,11 +465,11 @@ class Charm(object):
         if charm_type_id == MAINCHARE:
             assert not self.mainchareRegistered, 'More than one entry point has been specified'
             self.mainchareRegistered = True
-            # make mainchare constructor always threaded
+            # make mainchare constructor always a coroutine
             if sys.version_info < (3, 0, 0):
-                entry_method.threaded(C.__init__.im_func)
+                entry_method.coro(C.__init__.im_func)
             else:
-                entry_method.threaded(C.__init__)
+                entry_method.coro(C.__init__)
         charm_type = chare.charm_type_id_to_class[charm_type_id]
         # print("charm4py: Registering class " + C.__name__, "as", charm_type.__name__, "type_id=", charm_type_id, charm_type)
         profilingOn = self.options.profiling
@@ -525,9 +525,9 @@ class Charm(object):
         from .pool import PoolScheduler, Worker
         if self.interactive:
             if sys.version_info < (3, 0, 0):
-                entry_method.threaded(PoolScheduler.start.im_func)
+                entry_method.coro(PoolScheduler.start.im_func)
             else:
-                entry_method.threaded(PoolScheduler.start)
+                entry_method.coro(PoolScheduler.start)
         self.register(PoolScheduler, (ARRAY,))
         self.register(Worker, (GROUP,))
 
@@ -572,7 +572,7 @@ class Charm(object):
             self.interactive = True
             self.dynamic_register.update({'charm': charm, 'Chare': Chare, 'Group': Group,
                                           'Array': Array, 'Reducer': self.reducers,
-                                          'threaded': entry_method.threaded})
+                                          'threaded': entry_method.coro, 'coro': entry_method.coro})
 
         if self.started:
             raise Charm4PyError('charm.start() can only be called once')
@@ -776,7 +776,7 @@ class Charm(object):
             if not hasattr(proxy, 'creation_future'):
                 if not proxy.__class__.__name__.endswith('Proxy'):
                     raise Charm4PyError('Did not pass a proxy to awaitCreation? ' + str(type(proxy)))
-                raise Charm4PyError('awaitCreation can only be used if creation triggered from threaded entry method')
+                raise Charm4PyError('awaitCreation can only be used if creation triggered from a coroutine entry method')
             proxy.creation_future.get()
             del proxy.creation_future
 

--- a/charm4py/entry_method.py
+++ b/charm4py/entry_method.py
@@ -172,11 +172,6 @@ def when(cond_str):
     return _when
 
 
-def threaded(func):
-    func._ck_coro = True
-    return func
-
-
 def coro(func):
     func._ck_coro = True
     return func

--- a/charm4py/entry_method.py
+++ b/charm4py/entry_method.py
@@ -16,12 +16,12 @@ class EntryMethod(object):
             self.running = False
 
         method = getattr(C, name)
-        if hasattr(method, '_ck_threaded'):
+        if hasattr(method, '_ck_coro'):
             if not profile:
                 self.run = self._run_th
             else:
                 self.run = self._run_th_prof
-            self.thread_notify = hasattr(method, '_ck_threaded_notify') and method._ck_threaded_notify
+            self.thread_notify = hasattr(method, '_ck_coro_notify') and method._ck_coro_notify
         else:
             if not profile:
                 self.run = self._run
@@ -173,16 +173,21 @@ def when(cond_str):
 
 
 def threaded(func):
-    func._ck_threaded = True
+    func._ck_coro = True
     return func
 
 
-def threaded_ext(event_notify=False):
-    def _threaded(func):
-        func._ck_threaded = True
-        func._ck_threaded_notify = event_notify
+def coro(func):
+    func._ck_coro = True
+    return func
+
+
+def coro_ext(event_notify=False):
+    def _coro(func):
+        func._ck_coro = True
+        func._ck_coro_notify = event_notify
         return func
-    return _threaded
+    return _coro
 
 
 def charmStarting():

--- a/charm4py/interactive.py
+++ b/charm4py/interactive.py
@@ -1,4 +1,4 @@
-from . import charm, Chare, threaded, Future
+from . import charm, Chare, coro, Future
 from . import chare
 import sys
 import time
@@ -66,7 +66,7 @@ class InteractiveConsole(Chare, InteractiveInterpreter):
             # go through charm scheduler to keep things moving
             self.thisProxy.null(ret=1).get()
 
-    @threaded
+    @coro
     def start(self):
         self.write('\nCharm4py interactive shell (beta)\n')
         self.write('charm.options.interactive.verbose = ' + str(self.options.verbose) + '\n')

--- a/charm4py/pool.py
+++ b/charm4py/pool.py
@@ -1,4 +1,4 @@
-from . import charm, Chare, Group, threaded_ext, threads, Future
+from . import charm, Chare, Group, coro_ext, threads, Future
 from .charm import Charm4PyError
 from .threads import NotThreadedError
 from collections import defaultdict
@@ -270,7 +270,7 @@ class Worker(Chare):
         # TODO: when to purge entries from this dict?
         self.funcs = {}  # job ID -> function used by this job ID
 
-    @threaded_ext(event_notify=True)
+    @coro_ext(event_notify=True)
     def runTaskSingleFunc_th(self, func, args, result_destination, job_id):
         self.runTaskSingleFunc(func, args, result_destination, job_id)
 
@@ -281,7 +281,7 @@ class Worker(Chare):
             func = self.funcs[job_id]
         self.runTask(func, args, result_destination, job_id)
 
-    @threaded_ext(event_notify=True)
+    @coro_ext(event_notify=True)
     def runTask_th(self, func, args, result_destination, job_id):
         self.runTask(func, args, result_destination, job_id)
 
@@ -303,7 +303,7 @@ class Worker(Chare):
             if not isinstance(result_destination, int):
                 result_destination.send(e)
 
-    @threaded_ext(event_notify=True)
+    @coro_ext(event_notify=True)
     def runChunkSingleFunc_th(self, func, chunk, result_destination, job_id):
         self.runChunkSingleFunc(func, chunk, result_destination, job_id)
 
@@ -318,7 +318,7 @@ class Worker(Chare):
         except Exception as e:
             self.send_chunk_exc(e, result_destination, job_id)
 
-    @threaded_ext(event_notify=True)
+    @coro_ext(event_notify=True)
     def runChunk_th(self, _, chunk, result_destination, job_id):
         try:
             results = [func(args) for func, args in chunk]

--- a/charm4py/threads.py
+++ b/charm4py/threads.py
@@ -124,9 +124,9 @@ class EntryMethodThreadManager(object):
             raise Charm4PyError('Migration of chares with active threads is not currently supported')
 
     def throwNotThreadedError(self):
-        raise NotThreadedError("Entry method '" + charm.last_em_exec.C.__name__ + "." +
+        raise NotThreadedError("Method '" + charm.last_em_exec.C.__name__ + "." +
                                charm.last_em_exec.name +
-                               "' must be marked as 'threaded' to block")
+                               "' must be a couroutine to be able to suspend (decorate it with @coro)")
 
     def pauseThread(self):
         """ Called by an entry method thread to wait for something.

--- a/tests/benchmark/pingpong.py
+++ b/tests/benchmark/pingpong.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Array, threaded, Future
+from charm4py import charm, Chare, Array, coro, Future
 from time import time
 import numpy as np
 
@@ -35,7 +35,7 @@ class Ping(Chare):
                 return
         self.neighbor.recv(data)
 
-    @threaded
+    @coro
     def recv_th(self, data):
         if self.myIndex == 0:
             self.iter += 1

--- a/tests/callbacks/callbacks.py
+++ b/tests/callbacks/callbacks.py
@@ -1,10 +1,10 @@
-from charm4py import charm, Chare, Group, Array, Reducer, threaded, Future
+from charm4py import charm, Chare, Group, Array, Reducer, coro, Future
 import sys
 
 
 class Controller(Chare):
 
-    @threaded
+    @coro
     def start(self, workers, callback):
         f = Future()
         workers.work(f)

--- a/tests/charm_remote.py
+++ b/tests/charm_remote.py
@@ -1,10 +1,10 @@
-from charm4py import charm, Chare, Group, threaded
+from charm4py import charm, Chare, Group, coro
 import random
 
 
 class Controller(Chare):
 
-    @threaded
+    @coro
     def start(self):
         # print('Controller running on PE', charm.myPe())
         for i in range(charm.numPes()):

--- a/tests/collections/async_array_creation.py
+++ b/tests/collections/async_array_creation.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Reducer, threaded, Future
+from charm4py import charm, Chare, Reducer, coro, Future
 
 
 class Test(Chare):
@@ -15,7 +15,7 @@ class Test(Chare):
 
 class Controller(Chare):
 
-    @threaded
+    @coro
     def start(self):
         assert charm.myPe() == 1
 

--- a/tests/collections/proxies_same_name.py
+++ b/tests/collections/proxies_same_name.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Group, threaded
+from charm4py import charm, Chare, Group, coro
 import proxies_same_name_aux
 
 
@@ -14,7 +14,7 @@ class Test(Chare):
     def __init__(self):
         assert charm.myPe() == 2
 
-    @threaded
+    @coro
     def test(self, proxy, method_name):
         assert getattr(proxy[1], method_name)(ret=1).get() == 32255
 

--- a/tests/collections/proxies_same_name_aux.py
+++ b/tests/collections/proxies_same_name_aux.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, threaded
+from charm4py import charm, Chare, coro
 
 
 class Hello(Chare):
@@ -13,6 +13,6 @@ class Test(Chare):
     def __init__(self):
         assert charm.myPe() == 1
 
-    @threaded
+    @coro
     def test(self, proxy, method_name):
         assert getattr(proxy[3], method_name)(ret=1).get() == 68425

--- a/tests/entry_methods/retmodes.py
+++ b/tests/entry_methods/retmodes.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Group, Array, Reducer, threaded, Future
+from charm4py import charm, Chare, Group, Array, Reducer, coro, Future
 import random
 
 
@@ -17,7 +17,7 @@ class Test(Chare):
                 self.contribute(None, None, self.callback_test_done)
         return self.myval
 
-    @threaded
+    @coro
     def getVal_th(self, bcast):
         return self.getVal(bcast)
 

--- a/tests/exceptions/test.py
+++ b/tests/exceptions/test.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Group, Array, threaded
+from charm4py import charm, Chare, Group, Array, coro
 
 
 class Test(Chare):
@@ -23,15 +23,15 @@ class Test(Chare):
     def good(self):
         return self.idx
 
-    @threaded
+    @coro
     def bad_th(self):
         return self.bad()
 
-    @threaded
+    @coro
     def allbad_th(self):
         return self.allbad()
 
-    @threaded
+    @coro
     def good_th(self):
         return self.good()
 

--- a/tests/reductions/allreduce.py
+++ b/tests/reductions/allreduce.py
@@ -1,9 +1,9 @@
-from charm4py import charm, Chare, Group, Array, Reducer, threaded
+from charm4py import charm, Chare, Group, Array, Reducer, coro
 
 
 class Test(Chare):
 
-    @threaded
+    @coro
     def run(self, numChares, done_future):
         if isinstance(self.thisIndex, tuple):
             index = self.thisIndex[0]

--- a/tests/sections/allreduce.py
+++ b/tests/sections/allreduce.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Group, Array, threaded, Reducer, Future
+from charm4py import charm, Chare, Group, Array, coro, Reducer, Future
 
 
 NUM_ITER = 100
@@ -9,7 +9,7 @@ class Test(Chare):
     def __init__(self):
         self.numallreduce = 0
 
-    @threaded
+    @coro
     def work(self, f, numchares, secproxy=None):
         for _ in range(NUM_ITER):
             result = self.allreduce(1, Reducer.sum, section=secproxy).get()

--- a/tests/sections/constrained_groups.py
+++ b/tests/sections/constrained_groups.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Group, Reducer, threaded
+from charm4py import charm, Chare, Group, Reducer, coro
 import random
 
 
@@ -17,7 +17,7 @@ class Test(Chare):
     def getIdx(self):
         return self.thisIndex
 
-    @threaded
+    @coro
     def testallreduce(self):
         result = self.allreduce(self.thisIndex, Reducer.gather).get()
         assert result == sorted(section_pes)

--- a/tests/sections/slice.py
+++ b/tests/sections/slice.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Group, Array, threaded
+from charm4py import charm, Chare, Group, Array, coro
 
 
 class Test(Chare):
@@ -6,7 +6,7 @@ class Test(Chare):
     def getIdx(self):
         return self.thisIndex
 
-    @threaded
+    @coro
     def getIdx_th(self):
         return self.thisIndex
 

--- a/tests/thread_entry_methods/test1.py
+++ b/tests/thread_entry_methods/test1.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Array, Group, threaded, Reducer
+from charm4py import charm, Chare, Array, Group, coro, Reducer
 import time
 
 charm.options.profiling = True
@@ -12,7 +12,7 @@ class Test(Chare):
         # gather list of PEs on which each array element is located and broadcast to every member
         self.contribute(charm.myPe(), Reducer.gather, self.thisProxy.start)
 
-    @threaded
+    @coro
     def start(self, pes):
         for j in range(ITERATIONS):
             for i in range(numChares):
@@ -21,7 +21,7 @@ class Test(Chare):
 
         self.reduce(self.thisProxy.verify)
 
-    @threaded
+    @coro
     def getVal(self):
         return 53 * testGroup[charm.myPe()].getVal(ret=True).get() * self.thisIndex[0]
 

--- a/tests/thread_entry_methods/test1_when.py
+++ b/tests/thread_entry_methods/test1_when.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Array, Group, threaded, when, Reducer
+from charm4py import charm, Chare, Array, Group, coro, when, Reducer
 import time
 
 charm.options.profiling = True
@@ -14,7 +14,7 @@ class Test(Chare):
         # gather list of PEs on which each array element is located and broadcast to every member
         self.contribute(charm.myPe(), Reducer.gather, self.thisProxy.start)
 
-    @threaded
+    @coro
     def start(self, pes):
         for j in range(ITERATIONS):
             for i in range(numChares):
@@ -23,7 +23,7 @@ class Test(Chare):
 
         self.contribute(None, None, self.thisProxy[0].done)
 
-    @threaded
+    @coro
     @when('self.iteration == iteration')
     def getVal(self, iteration):
         result = 53 * testGroup[charm.myPe()].getVal(ret=True).get() * self.thisIndex[0] * self.iteration

--- a/tests/thread_entry_methods/test2.py
+++ b/tests/thread_entry_methods/test2.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Group, Array, threaded, Future
+from charm4py import charm, Chare, Group, Array, coro, Future
 
 
 NUM_ITER = 300
@@ -6,7 +6,7 @@ NUM_ITER = 300
 
 class Test(Chare):
 
-    @threaded
+    @coro
     def start(self, done_future):
         self.done_future = done_future
         self.iteration = 0
@@ -14,7 +14,7 @@ class Test(Chare):
             assert self.thisProxy[self.thisIndex].work(ret=1).get() == 3625
         self.reduce(self.thisProxy.verify)
 
-    @threaded
+    @coro
     def work(self):
         if self.iteration % 2 == 0:
             mype = charm.myPe()

--- a/tests/thread_entry_methods/threaded_ctors1.py
+++ b/tests/thread_entry_methods/threaded_ctors1.py
@@ -1,9 +1,9 @@
-from charm4py import charm, Chare, Group, Array, threaded
+from charm4py import charm, Chare, Group, Array, coro
 
 
 class Test(Chare):
 
-    @threaded
+    @coro
     def __init__(self, x):
         if charm.myPe() == 0:
             print(self.thisIndex, x)

--- a/tests/thread_entry_methods/threaded_ctors2.py
+++ b/tests/thread_entry_methods/threaded_ctors2.py
@@ -1,20 +1,20 @@
-from charm4py import charm, Chare, Group, Array, threaded
+from charm4py import charm, Chare, Group, Array, coro
 
 
 class A(Chare):
 
-    @threaded
+    @coro
     def __init__(self):
         self.x = 65824
 
-    @threaded
+    @coro
     def getVal(self):
         return self.x
 
 
 class B(Chare):
 
-    @threaded
+    @coro
     def __init__(self, grp_proxy):
         x = grp_proxy[self.thisIndex[0]].getVal(ret=True).get()
         assert x == 65824

--- a/tests/when/stencil.py
+++ b/tests/when/stencil.py
@@ -1,4 +1,4 @@
-from charm4py import charm, Chare, Array, threaded, when, Future
+from charm4py import charm, Chare, Array, coro, when, Future
 
 
 NUM_ITER = 500
@@ -16,7 +16,7 @@ class Cell(Chare):
         self.iteration = -1
         self.msgs_recvd = 0
 
-    @threaded
+    @coro
     def work(self, done_fut):
         for self.iteration in range(NUM_ITER):
             for nb in self.nbs:


### PR DESCRIPTION
Threaded entry methods are essentially coroutines. And the term
coroutine is now extended across multiple programming languages
to signify subroutines that cooperatively multitask
(non-preemptive multitasking) and which are usually implemented
using lightweight mechanisms that do not require the usual thread
overhead and synchronization (like locks). All of this applies
to Charm4py threaded entry methods, thus the name change.