### PR TITLE
Expose reference to InteractiveConsole via 'self' in interactive mode

### DIFF
--- a/charm4py/interactive.py
+++ b/charm4py/interactive.py
@@ -26,6 +26,7 @@ class InteractiveConsole(Chare, InteractiveInterpreter):
         os.dup2(charm.origStdinFd, 0)
         os.dup2(charm.origStoutFd, 1)
         charm.dynamic_register['future'] = future_
+        charm.dynamic_register['self'] = self
         InteractiveInterpreter.__init__(self, locals=charm.dynamic_register)
         self.filename = '<console>'
         self.resetbuffer()


### PR DESCRIPTION
InteractiveConsole is a chare (a mainchare). This exposes a
reference to it in the interactive prompt, via the 'self' name.
This allows establishing Channels in the interactive prompt
with remote chares, by:

channel = Channel(self, remote=other_chare)