### PR TITLE
Add awaitable keyword to proxy entry method calls; new ret behavior

### DIFF
--- a/charm4py/chare.py
+++ b/charm4py/chare.py
@@ -335,7 +335,7 @@ def mainchare_proxy_method_gen(ep, argcount, argnames, defaults):  # decorator, 
         header = {}
         blockFuture = None
         cid = proxy.cid  # chare ID
-        if 'ret' in kwargs and kwargs['ret']:
+        if ('ret' in kwargs and kwargs['ret']) or ('awaitable' in kwargs and kwargs['awaitable']):
             header[b'block'] = blockFuture = charm.Future()
         destObj = None
         if Options.local_msg_optim and (cid in charm.chares) and (len(args) > 0):
@@ -471,14 +471,14 @@ def group_proxy_method_gen(ep, argcount, argnames, defaults):  # decorator, gene
         header = {}
         blockFuture = None
         elemIdx = proxy.elemIdx
-        if 'ret' in kwargs:
-            retmode = kwargs['ret']
-            if retmode > 0:
-                header[b'block'] = blockFuture = charm.Future()
-                if elemIdx == -1:
-                    header[b'bcast'] = True
-                    if retmode > 1:
-                        header[b'bcastret'] = True
+        if 'ret' in kwargs and kwargs['ret']:
+            header[b'block'] = blockFuture = charm.Future()
+            if elemIdx == -1:
+                header[b'bcast'] = header[b'bcastret'] = True
+        elif 'awaitable' in kwargs and kwargs['awaitable']:
+            header[b'block'] = blockFuture = charm.Future()
+            if elemIdx == -1:
+                header[b'bcast'] = True
         if not proxy.issec or elemIdx != -1:
             destObj = None
             gid = proxy.gid
@@ -513,14 +513,14 @@ def update_globals_proxy_method_gen(ep):
         header = {}
         blockFuture = None
         elemIdx = proxy.elemIdx
-        if 'ret' in kwargs:
-            retmode = kwargs['ret']
-            if retmode > 0:
-                header[b'block'] = blockFuture = charm.Future()
-                if elemIdx == -1:
-                    header[b'bcast'] = True
-                    if retmode > 1:
-                        header[b'bcastret'] = True
+        if 'ret' in kwargs and kwargs['ret']:
+            header[b'block'] = blockFuture = charm.Future()
+            if elemIdx == -1:
+                header[b'bcast'] = header[b'bcastret'] = True
+        elif 'awaitable' in kwargs and kwargs['awaitable']:
+            header[b'block'] = blockFuture = charm.Future()
+            if elemIdx == -1:
+                header[b'bcast'] = True
         if not proxy.issec or elemIdx != -1:
             destObj = None
             gid = proxy.gid
@@ -731,14 +731,14 @@ def array_proxy_method_gen(ep, argcount, argnames, defaults):  # decorator, gene
         header = {}
         blockFuture = None
         elemIdx = proxy.elemIdx
-        if 'ret' in kwargs:
-            retmode = kwargs['ret']
-            if retmode > 0:
-                header[b'block'] = blockFuture = charm.Future()
-                if elemIdx == ():
-                    header[b'bcast'] = True
-                    if retmode > 1:
-                        header[b'bcastret'] = True
+        if 'ret' in kwargs and kwargs['ret']:
+            header[b'block'] = blockFuture = charm.Future()
+            if elemIdx == ():
+                header[b'bcast'] = header[b'bcastret'] = True
+        elif 'awaitable' in kwargs and kwargs['awaitable']:
+            header[b'block'] = blockFuture = charm.Future()
+            if elemIdx == ():
+                header[b'bcast'] = True
         if not proxy.issec or elemIdx != ():
             destObj = None
             aid = proxy.aid

--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -162,7 +162,7 @@ class Charm(object):
                 traceback.print_tb(stacktrace, limit=None)
             self.abort(errorType.__name__ + ': ' + str(error))
         else:
-            self.thisProxy[self.myPe()].propagateException(self.prepareExceptionForSend(error), ret=0)
+            self.thisProxy[self.myPe()].propagateException(self.prepareExceptionForSend(error))
 
     def prepareExceptionForSend(self, e):
         if not hasattr(e, 'remote_stacktrace'):

--- a/charm4py/interactive.py
+++ b/charm4py/interactive.py
@@ -65,7 +65,7 @@ class InteractiveConsole(Chare, InteractiveInterpreter):
         sys.stdout.flush()
         if sched:
             # go through charm scheduler to keep things moving
-            self.thisProxy.null(ret=1).get()
+            self.thisProxy.null(awaitable=True).get()
 
     @coro
     def start(self):
@@ -104,7 +104,7 @@ class InteractiveConsole(Chare, InteractiveInterpreter):
         more = self.runsource(source, self.filename)
         if not more:
             self.resetbuffer()
-            self.thisProxy.null(ret=1).get()
+            self.thisProxy.null(awaitable=True).get()
         return more
 
     def runcode(self, code):
@@ -114,7 +114,7 @@ class InteractiveConsole(Chare, InteractiveInterpreter):
                 if m is not None:
                     newChareTypeName = m.group(1)
                     source = '\n'.join(self.buffer)
-                    charm.thisProxy.registerNewChareType(newChareTypeName, source, ret=1).get()
+                    charm.thisProxy.registerNewChareType(newChareTypeName, source, awaitable=True).get()
                     if self.options.verbose > 0:
                         self.write('Charm4py> Broadcasted Chare definition\n')
                     return
@@ -135,7 +135,7 @@ class InteractiveConsole(Chare, InteractiveInterpreter):
                 if module_name not in sys.modules:  # error importing the module
                     return
                 if self.options.broadcast_imports:
-                    charm.thisProxy.rexec('\n'.join(self.buffer), ret=1).get()
+                    charm.thisProxy.rexec('\n'.join(self.buffer), awaitable=True).get()
                     if self.options.verbose > 0:
                         self.write('Charm4py> Broadcasted import statement\n')
 
@@ -158,7 +158,7 @@ class InteractiveConsole(Chare, InteractiveInterpreter):
                                                     ' Mainchare. Refer to new API')
                 if len(chare_types) > 0:
                     if self.options.broadcast_imports:
-                        charm.thisProxy.registerNewChareTypes(chare_types, ret=1).get()
+                        charm.thisProxy.registerNewChareTypes(chare_types, awaitable=True).get()
                         if self.options.verbose > 0:
                             self.write('Broadcasted the following chare definitions: ' + str([str(C) for C in chare_types]) + '\n')
                     else:

--- a/charm4py/pool.py
+++ b/charm4py/pool.py
@@ -116,10 +116,10 @@ class PoolScheduler(Chare):
         if charm.interactive:
             try:
                 if func is not None:
-                    self.workers.check(func.__module__, func.__name__, ret=1).get()
+                    self.workers.check(func.__module__, func.__name__, awaitable=True).get()
                 else:
                     for func_, args in tasks:
-                        self.workers.check(func_.__module__, func_.__name__, ret=1).get()
+                        self.workers.check(func_.__module__, func_.__name__, awaitable=True).get()
             except Exception as e:
                 if result is None:
                     raise e

--- a/examples/fibonacci/fib-numba.py
+++ b/examples/fibonacci/fib-numba.py
@@ -46,10 +46,10 @@ def main(args):
         GRAINSIZE = int(args[2])
     GRAINSIZE = max(2, GRAINSIZE)
     # set GRAINSIZE as a global variable on all processes before starting
-    charm.thisProxy.updateGlobals({'GRAINSIZE': GRAINSIZE}, ret=1).get()
+    charm.thisProxy.updateGlobals({'GRAINSIZE': GRAINSIZE}, awaitable=True).get()
     # precompile fib_seq on every process before the actual computation starts,
     # by calling the function. this helps get consistent benchmark results
-    charm.thisProxy.rexec('fib_seq(3)', ret=1).get()
+    charm.thisProxy.rexec('fib_seq(3)', awaitable=True).get()
     print('Calculating fibonacci of N=' + str(n) + ', grainsize=', GRAINSIZE)
     t0 = time.time()
     result = fib(n)

--- a/examples/hwmon/hwmon.py
+++ b/examples/hwmon/hwmon.py
@@ -20,7 +20,7 @@ class Controller(Chare):
             self.log = open(logfilename, 'a')
         else:
             self.log = sys.stdout
-        self.hosts = monitors.getHostName(ret=2).get()
+        self.hosts = monitors.getHostName(ret=True).get()
         for i, host in enumerate(self.hosts):
             print('Monitor', i, 'running on host', host)
         print('Going to run for', EXIT_AFTER_SECS, 'secs')

--- a/examples/jacobi/jacobi2d.py
+++ b/examples/jacobi/jacobi2d.py
@@ -174,7 +174,7 @@ def main(args):
                                    'blockDimY': blockDimY,
                                    'num_chare_x': num_chare_x,
                                    'num_chare_y': num_chare_y},
-                                   ret=True).get()
+                                   awaitable=True).get()
 
     print('\nRunning Jacobi on', charm.numPes(), 'processors with', num_chare_x, 'x', num_chare_y, 'chares')
     print('Array Dimensions:', arrayDimX, 'x', arrayDimY)
@@ -184,7 +184,7 @@ def main(args):
 
     if numbaFound:
         # wait until Numba functions are compiled on every PE, so we can get consistent benchmark results
-        charm.thisProxy.rexec('numba_precompile()', ret=True).get()
+        charm.thisProxy.rexec('numba_precompile()', awaitable=True).get()
         print('Numba compilation complete')
     else:
         print('!!WARNING!! Numba not found. Will run without Numba but it will be very slow')

--- a/examples/multi-module/main.py
+++ b/examples/multi-module/main.py
@@ -12,10 +12,10 @@ class Main(Chare):
         bye_chares = Group(goodbye.Goodbye)
         # add bye_chares proxy to globals of module hello on every process
         future1 = charm.thisProxy.updateGlobals({'bye_chares': bye_chares},
-                                                module_name='hello', ret=True)
+                                                module_name='hello', awaitable=True)
         # add mainchare proxy to globals of module goodbye on every process
         future2 = charm.thisProxy.updateGlobals({'mainProxy': self.thisProxy},
-                                                module_name='goodbye', ret=True)
+                                                module_name='goodbye', awaitable=True)
         charm.await((future1, future2))
         # broadcast a message to the hello chares
         hello_chares.SayHi()

--- a/examples/nqueen/nqueen-numba.py
+++ b/examples/nqueen/nqueen-numba.py
@@ -64,11 +64,11 @@ def main(args):
     global_data['NUM_ROWS'] = NUM_ROWS
     global_data['GRAINSIZE'] = GRAINSIZE
     global_data['solution_count'] = 0  # to count number of solutions found on each PE
-    charm.thisProxy.updateGlobals(global_data, ret=1).get()
+    charm.thisProxy.updateGlobals(global_data, awaitable=True).get()
 
     # compile numba functions on every PE before starting, to get
     # consistent benchmark results
-    charm.thisProxy.rexec('numbaPrecompile()', ret=1).get()
+    charm.thisProxy.rexec('numbaPrecompile()', awaitable=True).get()
 
     startTime = time()
     # initialize empty solution, solution holds the column number where a queen is placed, for each row
@@ -77,7 +77,7 @@ def main(args):
     # wait until there is no work being done on any PE (quiescence detection)
     charm.waitQD()
     elapsed = time() - startTime
-    numSolutions = sum(charm.thisProxy.eval('solution_count', ret=2).get())
+    numSolutions = sum(charm.thisProxy.eval('solution_count', ret=True).get())
     print('There are', numSolutions, 'solutions to', NUM_ROWS, 'queens. Time taken:', round(elapsed, 3), 'secs')
     exit()
 

--- a/examples/nqueen/nqueen.py
+++ b/examples/nqueen/nqueen.py
@@ -52,7 +52,7 @@ def main(args):
     global_data['NUM_ROWS'] = NUM_ROWS
     global_data['GRAINSIZE'] = GRAINSIZE
     global_data['solution_count'] = 0  # to count number of solutions found on each PE
-    charm.thisProxy.updateGlobals(global_data, ret=1).get()
+    charm.thisProxy.updateGlobals(global_data, awaitable=True).get()
 
     startTime = time()
     # initialize empty solution, solution holds the column number where a queen is placed, for each row
@@ -61,7 +61,7 @@ def main(args):
     # wait until there is no work being done on any PE (quiescence detection)
     charm.waitQD()
     elapsed = time() - startTime
-    numSolutions = sum(charm.thisProxy.eval('solution_count', ret=2).get())
+    numSolutions = sum(charm.thisProxy.eval('solution_count', ret=True).get())
     print('There are', numSolutions, 'solutions to', NUM_ROWS, 'queens. Time taken:', round(elapsed, 3), 'secs')
     exit()
 

--- a/examples/particle/particle.py
+++ b/examples/particle/particle.py
@@ -172,7 +172,7 @@ def main(args):
     cells = Array(Cell, array_dims,
                   args=[array_dims, max_particles_per_cell_start, sim_done],
                   useAtSync=True)
-    num_particles_per_cell = cells.getNumParticles(ret=2).get()
+    num_particles_per_cell = cells.getNumParticles(ret=True).get()
     print('Total particles created:', sum(num_particles_per_cell))
     print('Initial conditions:\n\tmin particles per cell:', min(num_particles_per_cell),
           '\n\tmax particles per cell:', max(num_particles_per_cell))

--- a/examples/simple/hello_world.py
+++ b/examples/simple/hello_world.py
@@ -11,7 +11,7 @@ def main(args):
     # create Group of Hello objects (there will be one object on each core)
     hellos = Group(Hello)
     # call method 'SayHi' of all group members, wait for method to be invoked on all
-    hellos.SayHi(ret=True).get()
+    hellos.SayHi(awaitable=True).get()
     exit()
 
 

--- a/tests/channels/test2.py
+++ b/tests/channels/test2.py
@@ -78,11 +78,11 @@ def main(args):
                 num_self_channels += 1
             gchannels[level][a].append(b)
             gchannels[level][b].append(a)
-    charm.thisProxy.updateGlobals({'gchannels': gchannels}, ret=1).get()
+    charm.thisProxy.updateGlobals({'gchannels': gchannels}, awaitable=True).get()
 
     done_fut = Future(8 * NUM_LEVELS)  # wait for 8 collections to finish 3 levels
     for collection in (g1, g2, g3, g4, a1, a2, a3, a4):
-        collection.setup(ret=1).get()
+        collection.setup(awaitable=True).get()
     print(NUM_CHANNELS * NUM_LEVELS, 'channels set up,', num_self_channels, 'self channels')
     for collection in (g1, g2, g3, g4, a1, a2, a3, a4):
         for lvl in range(NUM_LEVELS):

--- a/tests/charm_remote.py
+++ b/tests/charm_remote.py
@@ -13,7 +13,7 @@ class Controller(Chare):
         pe = charm.myPe() - 1
         if pe == -1:
             pe = 0
-        charm.thisProxy[pe].exec('global MY_GLOBAL; MY_GLOBAL = 7262', __name__, ret=True).get()
+        charm.thisProxy[pe].exec('global MY_GLOBAL; MY_GLOBAL = 7262', __name__, awaitable=True).get()
         assert charm.thisProxy[pe].eval('MY_GLOBAL', __name__, ret=True).get() == 7262
 
         Group(Test)

--- a/tests/collections/proxies_same_name.py
+++ b/tests/collections/proxies_same_name.py
@@ -16,7 +16,7 @@ class Test(Chare):
 
     @coro
     def test(self, proxy, method_name):
-        assert getattr(proxy[1], method_name)(ret=1).get() == 32255
+        assert getattr(proxy[1], method_name)(ret=True).get() == 32255
 
 
 def main(args):
@@ -26,8 +26,8 @@ def main(args):
     tester1 = Chare(Test, onPE=2)
     tester2 = Chare(proxies_same_name_aux.Test, onPE=1)
     charm.awaitCreation(g2, g1, tester2, tester1)
-    tester1.test(g2, 'check2', ret=1).get()
-    tester2.test(g1, 'check1', ret=1).get()
+    tester1.test(g2, 'check2', awaitable=True).get()
+    tester2.test(g1, 'check1', awaitable=True).get()
     exit()
 
 

--- a/tests/collections/proxies_same_name_aux.py
+++ b/tests/collections/proxies_same_name_aux.py
@@ -15,4 +15,4 @@ class Test(Chare):
 
     @coro
     def test(self, proxy, method_name):
-        assert getattr(proxy[3], method_name)(ret=1).get() == 68425
+        assert getattr(proxy[3], method_name)(ret=True).get() == 68425

--- a/tests/collections/proxy_eq.py
+++ b/tests/collections/proxy_eq.py
@@ -24,20 +24,20 @@ class Main(Chare):
         assert self.thisProxy != a
 
         assert g1 == g1
-        assert g1 == g1[2].getProxy(ret=1).get()
-        assert g1[2] == g1[2].getProxy(elem=True, ret=1).get()
-        assert g1[2].getProxy(ret=1).get() == g1[3].getProxy(ret=1).get()
-        assert g1[2].getProxy(True, ret=1).get() != g1[3].getProxy(True, ret=1).get()
+        assert g1 == g1[2].getProxy(ret=True).get()
+        assert g1[2] == g1[2].getProxy(elem=True, ret=True).get()
+        assert g1[2].getProxy(ret=True).get() == g1[3].getProxy(ret=True).get()
+        assert g1[2].getProxy(True, ret=True).get() != g1[3].getProxy(True, ret=True).get()
 
         assert g1 != g2
-        assert g1[2].getProxy(ret=1).get() != g2[2].getProxy(ret=1).get()
-        assert g1[2].getProxy(True, ret=1).get() != g2[2].getProxy(True, ret=1).get()
+        assert g1[2].getProxy(ret=True).get() != g2[2].getProxy(ret=True).get()
+        assert g1[2].getProxy(True, ret=True).get() != g2[2].getProxy(True, ret=True).get()
 
         assert g1 != a
         assert a == a
-        assert a == a[12].getProxy(ret=1).get()
-        assert a[12] == a[12].getProxy(elem=True, ret=1).get()
-        assert a[8] != a[12].getProxy(elem=True, ret=1).get()
+        assert a == a[12].getProxy(ret=True).get()
+        assert a[12] == a[12].getProxy(elem=True, ret=True).get()
+        assert a[8] != a[12].getProxy(elem=True, ret=True).get()
 
         exit()
 

--- a/tests/dcopy/test_dcopy.py
+++ b/tests/dcopy/test_dcopy.py
@@ -16,7 +16,7 @@ CHARES_PER_PE = 10
 class Main(Chare):
 
     def __init__(self, args):
-        charm.thisProxy.updateGlobals({'mainProxy' : self.thisProxy}, '__main__', ret=True).get()
+        charm.thisProxy.updateGlobals({'mainProxy' : self.thisProxy}, '__main__', awaitable=True).get()
         self.testProxy = Array(Test, charm.numPes() * CHARES_PER_PE)
 
     def start(self):

--- a/tests/entry_methods/bcast_globals.py
+++ b/tests/entry_methods/bcast_globals.py
@@ -22,7 +22,7 @@ def main(args):
     main_globals['group1_proxy'] = g1
     main_globals['group2_proxy'] = g2
     main_globals['done_future'] = done
-    charm.thisProxy.updateGlobals(main_globals, module_name='__main__', ret=True).get()
+    charm.thisProxy.updateGlobals(main_globals, module_name='__main__', awaitable=True).get()
 
     group1_proxy.start()
     done.get()

--- a/tests/entry_methods/entrymethod_args_kwargs.py
+++ b/tests/entry_methods/entrymethod_args_kwargs.py
@@ -36,42 +36,42 @@ class Main(Chare):
         g = Group(Test)
         a = Array(Test, charm.numPes() * 4)
 
-        self.thisProxy.startPhase(1, 2, 33, 44, ret=True).get()
-        g.startPhase(1, 2, 33, 44, ret=True).get()
-        a.startPhase(1, 2, 33, 44, ret=True).get()
+        self.thisProxy.startPhase(1, 2, 33, 44, awaitable=True).get()
+        g.startPhase(1, 2, 33, 44, awaitable=True).get()
+        a.startPhase(1, 2, 33, 44, awaitable=True).get()
         for collection in (g, a, self.thisProxy):
-            collection.recv(1, 2, ret=True).get()
-            collection.recv(1, 2, 33, ret=True).get()
-            collection.recv(1, 2, 33, 44, ret=True).get()
-            collection.recv(y=2, x=1, ret=True).get()
-            collection.recv(b=44, a=33, y=2, x=1, ret=True).get()
+            collection.recv(1, 2, awaitable=True).get()
+            collection.recv(1, 2, 33, awaitable=True).get()
+            collection.recv(1, 2, 33, 44, awaitable=True).get()
+            collection.recv(y=2, x=1, awaitable=True).get()
+            collection.recv(b=44, a=33, y=2, x=1, awaitable=True).get()
             if collection == g:
                 single_chare = 1
             elif collection == a:
                 single_chare = 4
             else:
                 continue
-            collection[single_chare].recv(1, 2, ret=True).get()
-            collection[single_chare].recv(1, 2, 33, ret=True).get()
-            collection[single_chare].recv(1, 2, 33, 44, ret=True).get()
-            collection[single_chare].recv(y=2, x=1, ret=True).get()
-            collection[single_chare].recv(b=44, a=33, y=2, x=1, ret=True).get()
+            collection[single_chare].recv(1, 2, awaitable=True).get()
+            collection[single_chare].recv(1, 2, 33, awaitable=True).get()
+            collection[single_chare].recv(1, 2, 33, 44, awaitable=True).get()
+            collection[single_chare].recv(y=2, x=1, awaitable=True).get()
+            collection[single_chare].recv(b=44, a=33, y=2, x=1, awaitable=True).get()
 
-        self.thisProxy.startPhase(10, 20, 3000, 4000, ret=True).get()
-        g.startPhase(10, 20, 3000, 4000, ret=True).get()
-        a.startPhase(10, 20, 3000, 4000, ret=True).get()
+        self.thisProxy.startPhase(10, 20, 3000, 4000, awaitable=True).get()
+        g.startPhase(10, 20, 3000, 4000, awaitable=True).get()
+        a.startPhase(10, 20, 3000, 4000, awaitable=True).get()
         for collection in (g, a, self.thisProxy):
-            collection.recv(10, 20, 3000, 4000, ret=True).get()
-            collection.recv(10, 20, 3000, b=4000, ret=True).get()
-            collection.recv(b=4000, a=3000, y=20, x=10, ret=True).get()
+            collection.recv(10, 20, 3000, 4000, awaitable=True).get()
+            collection.recv(10, 20, 3000, b=4000, awaitable=True).get()
+            collection.recv(b=4000, a=3000, y=20, x=10, awaitable=True).get()
             if collection == g:
                 single_chare = 1
             elif collection == a:
                 single_chare = 4
             else:
                 continue
-            collection[single_chare].recv(10, 20, 3000, b=4000, ret=True).get()
-            collection[single_chare].recv(b=4000, a=3000, y=20, x=10, ret=True).get()
+            collection[single_chare].recv(10, 20, 3000, b=4000, awaitable=True).get()
+            collection[single_chare].recv(b=4000, a=3000, y=20, x=10, awaitable=True).get()
 
         exit()
 

--- a/tests/entry_methods/retmodes.py
+++ b/tests/entry_methods/retmodes.py
@@ -37,40 +37,34 @@ def main(args):
         indexes = list(range(num_elems))
         random_idxs = random.sample(indexes, int(max(len(indexes) * 0.8, 1)))
         for random_idx in random_idxs:
-            retval = collection[random_idx].getVal(False, ret=0)
+            retval = collection[random_idx].getVal(False, awaitable=False, ret=False)
             assert retval is None
 
-            retval = collection[random_idx].getVal(False, ret=1).get()
+            retval = collection[random_idx].getVal(False, ret=True).get()
             assert retval == vals[random_idx]
 
-            retval = collection[random_idx].getVal(False, ret=2).get()
-            assert retval == vals[random_idx]
-
-            retval = collection[random_idx].getVal_th(False, ret=0)
+            retval = collection[random_idx].getVal_th(False, awaitable=False, ret=False)
             assert retval is None
 
-            retval = collection[random_idx].getVal_th(False, ret=1).get()
+            retval = collection[random_idx].getVal_th(False, ret=True).get()
             assert retval == vals[random_idx]
 
-            retval = collection[random_idx].getVal_th(False, ret=2).get()
-            assert retval == vals[random_idx]
-
-        retval = collection.getVal(True, ret=0)
+        retval = collection.getVal(True, ret=False)
         assert retval is None
 
-        retval = collection.getVal(True, ret=1).get()
+        retval = collection.getVal(True, awaitable=True).get()
         assert retval is None
 
-        retval = collection.getVal(True, ret=2).get()
+        retval = collection.getVal(True, ret=True).get()
         assert retval == [vals[i] for i in range(num_elems)]
 
-        retval = collection.getVal_th(True, ret=0)
+        retval = collection.getVal_th(True, awaitable=False)
         assert retval is None
 
-        retval = collection.getVal_th(True, ret=1).get()
+        retval = collection.getVal_th(True, awaitable=True).get()
         assert retval is None
 
-        retval = collection.getVal_th(True, ret=2).get()
+        retval = collection.getVal_th(True, ret=True).get()
         assert retval == [vals[i] for i in range(num_elems)]
 
     done1.get()

--- a/tests/exceptions/pool.py
+++ b/tests/exceptions/pool.py
@@ -28,10 +28,10 @@ def main(args):
         for trial in range(2):
             if trial == 0:
                 # use bad func
-                charm.thisProxy.rexec(myfunc_bad_source, ret=1).get()
+                charm.thisProxy.rexec(myfunc_bad_source, awaitable=True).get()
             else:
                 # use good func
-                charm.thisProxy.rexec(myfunc_good_source, ret=1).get()
+                charm.thisProxy.rexec(myfunc_good_source, awaitable=True).get()
 
             for func in (myfunc, None):
                 for multi_future in (False, True):

--- a/tests/exceptions/test.py
+++ b/tests/exceptions/test.py
@@ -58,28 +58,28 @@ def main(args):
                 bad_idx = (num_chares // 2) + 1
             for _ in range(NUM_ITER):
                 try:
-                    getattr(proxy[bad_idx], methods['bad'])(ret=1).get()
+                    getattr(proxy[bad_idx], methods['bad'])(ret=True).get()
                     assert False
                 except NameError:
-                    retval = getattr(proxy[bad_idx], methods['good'])(ret=1).get()
+                    retval = getattr(proxy[bad_idx], methods['good'])(ret=True).get()
                     assert retval == bad_idx
 
-            # bcast ret=1
+            # bcast awaitable=True
             for _ in range(NUM_ITER):
                 try:
-                    getattr(proxy, methods['allbad'])(ret=1).get()
+                    getattr(proxy, methods['allbad'])(awaitable=True).get()
                     assert False
                 except NameError:
                     try:
-                        getattr(proxy, methods['bad'])(ret=1).get()
+                        getattr(proxy, methods['bad'])(awaitable=True).get()
                         assert False
                     except NameError:
-                        retval = getattr(proxy, methods['good'])(ret=1).get()
+                        retval = getattr(proxy, methods['good'])(awaitable=True).get()
                         assert retval is None
 
-            # bcast ret=2 (returns list of results)
+            # bcast ret=True (returns list of results)
             for _ in range(NUM_ITER):
-                retvals = getattr(proxy, methods['bad'])(ret=2).get()
+                retvals = getattr(proxy, methods['bad'])(ret=True).get()
                 num_errors = 0
                 for retval in retvals:
                     if isinstance(retval, NameError):

--- a/tests/interactive/test1.in
+++ b/tests/interactive/test1.in
@@ -8,7 +8,7 @@ def my_except_hook(errorType, error, tb):
 sys.excepthook = my_except_hook
 
 import os
-charm.thisProxy.rexec("sys.path.append(os.path.join(os.getcwd(), 'tests', 'interactive'))", ret=True).get()
+charm.thisProxy.rexec("sys.path.append(os.path.join(os.getcwd(), 'tests', 'interactive'))", awaitable=True).get()
 
 assert charm.myPe() == 0
 
@@ -35,8 +35,8 @@ def myreducer(contribs):
     return [6282 for _ in range(len(contribs))]
 '''
 
-charm.thisProxy.exec(myreducer_src, ret=1).get()
-charm.thisProxy.addReducer(myreducer, ret=1).get()
+charm.thisProxy.exec(myreducer_src, awaitable=True).get()
+charm.thisProxy.addReducer(myreducer, awaitable=True).get()
 g.work2(future())
 assert all([x == 6282 for x in _f.get()])
 

--- a/tests/migration/test_migrate.py
+++ b/tests/migration/test_migrate.py
@@ -46,7 +46,7 @@ def main(args):
     home_pes = Future()
     array = Array(Test, charm.numPes() * 4, args=[home_pes], useAtSync=True)
     charm.thisProxy.updateGlobals({'all_created' : True, 'arrayElemHomeMap' : home_pes.get()},
-                                  '__main__', ret=True).get()
+                                  '__main__', awaitable=True).get()
     array.start()
 
 

--- a/tests/reductions/array_reduction.py
+++ b/tests/reductions/array_reduction.py
@@ -31,7 +31,7 @@ class Main(Chare):
         arrProxy = Array(Test, ARRAY_SIZE)
         groupProxy = Group(TestGroup)
         charm.thisProxy.updateGlobals({'mainProxy': self.thisProxy, 'arrProxy': arrProxy,
-                                       'groupProxy': groupProxy}, '__main__', ret=True).get()
+                                       'groupProxy': groupProxy}, '__main__', awaitable=True).get()
         arrProxy.doReduction()
 
     def done_int(self, reduction_result):

--- a/tests/reductions/bench_reductions.py
+++ b/tests/reductions/bench_reductions.py
@@ -17,7 +17,7 @@ class Main(Chare):
 
     def __init__(self, args):
         charm.thisProxy.updateGlobals({'mainProxy': self.thisProxy,
-                                       'NUM_CHARES': charm.numPes() * CHARES_PER_PE}, '__main__', ret=True).get()
+                                       'NUM_CHARES': charm.numPes() * CHARES_PER_PE}, '__main__', awaitable=True).get()
         self.arrayProxy = Array(Test, NUM_CHARES)
         self.arrayProxy.run()
         self.startTime = time.time()

--- a/tests/reductions/custom_reduction.py
+++ b/tests/reductions/custom_reduction.py
@@ -28,7 +28,7 @@ class Main(Chare):
         print('Running reduction example on ' + str(charm.numPes()) + ' processors for ' + str(self.nElements) + ' elements, array dims=' + str(ARRAY_SIZE))
         arrProxy = Array(Test, ARRAY_SIZE)
         charm.thisProxy.updateGlobals({'mainProxy': self.thisProxy, 'arrProxy': arrProxy,
-                                       'lastIdx': lastIdx}, '__main__', ret=True).get()
+                                       'lastIdx': lastIdx}, '__main__', awaitable=True).get()
         arrProxy.doReduction()
 
     def done_charm_builtin(self, result):

--- a/tests/reductions/group_reduction.py
+++ b/tests/reductions/group_reduction.py
@@ -29,7 +29,7 @@ class Main(Chare):
         # create an array to test group-to-array reductions
         arrayProxy = Array(TestArray, ARRAY_SIZE)
         charm.thisProxy.updateGlobals({'mainProxy': self.thisProxy, 'arrayProxy': arrayProxy},
-                                       '__main__', ret=True).get()
+                                       '__main__', awaitable=True).get()
         groupProxy.doReduction()
 
     def done_int(self, reduction_result):

--- a/tests/reductions/test_gather.py
+++ b/tests/reductions/test_gather.py
@@ -18,7 +18,7 @@ class Main(Chare):
         print('Running gather example on', charm.numPes(), 'processors for', self.nElements, 'elements, array dims=', ARRAY_SIZE)
         arrProxy = Array(Test, ARRAY_SIZE)
         grpProxy = Group(TestGroup)
-        charm.thisProxy.updateGlobals({'mainProxy': self.thisProxy}, '__main__', ret=True).get()
+        charm.thisProxy.updateGlobals({'mainProxy': self.thisProxy}, '__main__', awaitable=True).get()
         arrProxy.doGather()
         grpProxy.doGather()
         red_future = charm.Future()

--- a/tests/sections/allreduce.py
+++ b/tests/sections/allreduce.py
@@ -34,7 +34,7 @@ def main(args):
     g.work(f, charm.numPes())
     gsec.work(f, charm.numPes() // 2, gsec)
     f.get()
-    g.verify(ret=1).get()
+    g.verify(awaitable=True).get()
     exit()
 
 

--- a/tests/sections/callbacks.py
+++ b/tests/sections/callbacks.py
@@ -65,76 +65,76 @@ def main(args):
 
     g = Group(Test)
     g_sec = charm.split(g, 1, odd_idx_chares)[0]
-    g.setSecProxy(g_sec, ret=1).get()
+    g.setSecProxy(g_sec, awaitable=True).get()
     collections.append((g, g_sec, charm.numPes()))
 
     N = charm.numPes() * 10
     a = Array(Test, N)
     a_sec = charm.split(a, 1, odd_idx_chares)[0]
-    a.setSecProxy(a_sec, ret=1).get()
+    a.setSecProxy(a_sec, awaitable=True).get()
     collections.append((a, a_sec, N))
 
     for collection, secProxy, numchares in collections:
 
         f = Future()
         expected = numchares * 3
-        collection.setTest(f, expected, ret=1).get()
+        collection.setTest(f, expected, awaitable=True).get()
         collection.work1(secProxy.recvResult)
         assert f.get() == (numchares // 2)
 
         f = Future()
         expected = (numchares // 2) * 3
-        secProxy.setTest(f, expected, ret=1).get()
+        secProxy.setTest(f, expected, awaitable=True).get()
         secProxy.work1(secProxy.recvResult, secProxy)
         assert f.get() == (numchares // 2)
 
         f = Future()
         expected = numpy.arange(100, dtype='float64')
         expected *= numchares
-        collection.setTest(f, expected, ret=1).get()
+        collection.setTest(f, expected, awaitable=True).get()
         collection.work2(secProxy.recvResult)
         assert f.get() == (numchares // 2)
 
         f = Future()
         expected = numpy.arange(100, dtype='float64')
         expected *= (numchares // 2)
-        secProxy.setTest(f, expected, ret=1).get()
+        secProxy.setTest(f, expected, awaitable=True).get()
         secProxy.work2(secProxy.recvResult, secProxy)
         assert f.get() == (numchares // 2)
 
         f = Future()
         expected = [str(i) for i in range(numchares)]
-        collection.setTest(f, expected, ret=1).get()
+        collection.setTest(f, expected, awaitable=True).get()
         collection.work3(secProxy.recvResult)
         assert f.get() == (numchares // 2)
 
         f = Future()
         expected = [str(i) for i in range(numchares) if i % 2 == 1]
-        secProxy.setTest(f, expected, ret=1).get()
+        secProxy.setTest(f, expected, awaitable=True).get()
         secProxy.work3(secProxy.recvResult, secProxy)
         assert f.get() == (numchares // 2)
 
         f = Future()
         expected = None
-        collection.setTest(f, expected, ret=1).get()
+        collection.setTest(f, expected, awaitable=True).get()
         collection.work4(secProxy.recvResult)
         assert f.get() == (numchares // 2)
 
         f = Future()
         expected = None
-        secProxy.setTest(f, expected, ret=1).get()
+        secProxy.setTest(f, expected, awaitable=True).get()
         secProxy.work4(secProxy.recvResult, secProxy)
         assert f.get() == (numchares // 2)
 
         f = Future()
         expected = 'test section callback'
-        collection.setTest(f, expected, ret=1).get()
+        collection.setTest(f, expected, awaitable=True).get()
         collection.work5(secProxy.recvResult)
         assert f.get() == (numchares // 2)
 
         f = Future()
         expected = None
-        collection.setTest(f, expected, ret=1).get()
+        collection.setTest(f, expected, awaitable=True).get()
         charm.startQD(secProxy.recvResult)
         assert f.get() == (numchares // 2)
 

--- a/tests/sections/constrained_groups.py
+++ b/tests/sections/constrained_groups.py
@@ -26,15 +26,15 @@ class Test(Chare):
 def main(args):
     assert charm.numPes() > 1
     section_pes = random.sample(range(charm.numPes()), charm.numPes() // 2)
-    charm.thisProxy.updateGlobals({'section_pes': section_pes}, ret=1).get()
+    charm.thisProxy.updateGlobals({'section_pes': section_pes}, awaitable=True).get()
     g = Group(Test, onPEs=section_pes, args=[4862])
-    assert g[section_pes[0]].test2(ret=1).get() == 34589
-    g.test(ret=1).get()
+    assert g[section_pes[0]].test2(ret=True).get() == 34589
+    g.test(awaitable=True).get()
 
-    assert g.getIdx(ret=2).get() == sorted(section_pes)
-    assert g[section_pes[0]].getIdx(ret=1).get() == section_pes[0]
+    assert g.getIdx(ret=True).get() == sorted(section_pes)
+    assert g[section_pes[0]].getIdx(ret=True).get() == section_pes[0]
 
-    g.testallreduce(ret=1).get()
+    g.testallreduce(awaitable=True).get()
 
     exit()
 

--- a/tests/sections/multirand-split-combine.py
+++ b/tests/sections/multirand-split-combine.py
@@ -92,7 +92,7 @@ class Collection(object):
                     if (cid, idx) not in insections:
                         insections[(cid, idx)] = []
                     insections[(cid, idx)].append(i)
-        charm.thisProxy.updateGlobals({'insections': insections}, ret=1).get()
+        charm.thisProxy.updateGlobals({'insections': insections}, awaitable=True).get()
         assert len(sections) == N
         for section in sections:
             assert len(section) > 0
@@ -180,11 +180,11 @@ def main(args):
         if c.proxy.issec:
             # this is a section proxy
             sid = c.proxy.section[1]
-            c.proxy.recvSecProxy(sid, c.proxy, ret=1).get()
+            c.proxy.recvSecProxy(sid, c.proxy, awaitable=True).get()
 
     for _ in range(NUM_ITER):
         futures = [Future() for _ in range(len(collections))]
-        charm.thisProxy.updateGlobals({'DATA_VERIFY' : random.randint(0,100000)}, ret=1).get()
+        charm.thisProxy.updateGlobals({'DATA_VERIFY' : random.randint(0,100000)}, awaitable=True).get()
         data = DATA_VERIFY
         for i, c in enumerate(collections):
             sid = None

--- a/tests/sections/simple.py
+++ b/tests/sections/simple.py
@@ -35,21 +35,21 @@ def main(args):
     # for each array, create one section using member function to determine section membership
     for array, size in [(array2d, 8*8), (array3d, 4*5*3)]:
         secProxy = charm.split(array, 1, member)[0]
-        array.setSecProxy(secProxy, ret=1).get()
+        array.setSecProxy(secProxy, awaitable=True).get()
         f = Future()
         secProxy.ping(f)
         assert len(f.get()) < size
 
     # for each array, create one section passing a random list of element indexes (half the size of the array)
     for array, size in [(array2d, 8*8), (array3d, 4*5*3)]:
-        elems = array.getElems(ret=2).get()
+        elems = array.getElems(ret=True).get()
         assert len(elems) == size
         section_elems = random.sample(elems, size // 2)
         secProxy = charm.split(array, 1, elems=section_elems)[0]
         f = Future()
         secProxy.ping2(f, secProxy)
         assert f.get() == sorted(section_elems)
-        assert secProxy.getElems(ret=2).get() == sorted(section_elems)
+        assert secProxy.getElems(ret=True).get() == sorted(section_elems)
 
     exit()
 

--- a/tests/sections/slice.py
+++ b/tests/sections/slice.py
@@ -15,22 +15,22 @@ def main(args):
 
     g = Group(Test)
     elems = list(range(0, charm.numPes(), 2))
-    assert g[::2].getIdx(ret=2).get() == elems
-    assert g[0::2].getIdx_th(ret=2).get() == elems
-    assert g[:charm.numPes():2].getIdx(ret=2).get() == elems
-    assert g[0:charm.numPes()].getIdx_th(ret=2).get() != elems
+    assert g[::2].getIdx(ret=True).get() == elems
+    assert g[0::2].getIdx_th(ret=True).get() == elems
+    assert g[:charm.numPes():2].getIdx(ret=True).get() == elems
+    assert g[0:charm.numPes()].getIdx_th(ret=True).get() != elems
 
     a1 = Array(Test, (8,8))
     a2 = Array(Test, 64)
 
-    indexes = a1[0:8:2,1:8:2].getIdx(ret=2).get()
+    indexes = a1[0:8:2,1:8:2].getIdx(ret=True).get()
     assert len(indexes) == 8*8//4
     for idx in indexes:
         assert len(idx) == 2
         assert idx[0] % 2 == 0
         assert idx[1] % 2 != 0
 
-    indexes = a2[0:64:5].getIdx_th(ret=2).get()
+    indexes = a2[0:64:5].getIdx_th(ret=True).get()
     assert len(indexes) == 13
     for idx in indexes:
         assert len(idx) == 1

--- a/tests/thread_entry_methods/future_bcast.py
+++ b/tests/thread_entry_methods/future_bcast.py
@@ -19,7 +19,7 @@ def main(args):
     # to the other PEs, so I set wait time to 0 on PE 0
     sleepTimes[0] = 0.0
     t0 = time.time()
-    a.work(sleepTimes, ret=True).get()  # wait for broadcast to complete
+    a.work(sleepTimes, awaitable=True).get()  # wait for broadcast to complete
     wait_time = time.time() - t0
     assert(wait_time >= max(sleepTimes))
     print(wait_time, max(sleepTimes))
@@ -28,7 +28,7 @@ def main(args):
     sleepTimes = [random.uniform(0.5, 1.5) for i in range(charm.numPes())]
     sleepTimes[0] = 0.0
     t0 = time.time()
-    g.work(sleepTimes, ret=True).get()  # wait for broadcast to complete
+    g.work(sleepTimes, awaitable=True).get()  # wait for broadcast to complete
     wait_time = time.time() - t0
     assert(wait_time >= max(sleepTimes))
     print(wait_time, max(sleepTimes))

--- a/tests/thread_entry_methods/test1.py
+++ b/tests/thread_entry_methods/test1.py
@@ -45,7 +45,7 @@ def main(args):
     numChares = min(charm.numPes() * 8, 32)
     testGroup = Group(Test2)
     charm.thisProxy.updateGlobals({'numChares': numChares, 'testGroup': testGroup},
-                                  '__main__', ret=True).get()
+                                  '__main__', awaitable=True).get()
     Array(Test, numChares)
 
 

--- a/tests/thread_entry_methods/test1_when.py
+++ b/tests/thread_entry_methods/test1_when.py
@@ -49,7 +49,7 @@ def main(args):
     numChares = min(charm.numPes() * 8, 32)
     testGroup = Group(Test2)
     charm.thisProxy.updateGlobals({'numChares': numChares, 'testGroup': testGroup},
-                                  '__main__', ret=True).get()
+                                  '__main__', awaitable=True).get()
     Array(Test, numChares)
 
 

--- a/tests/thread_entry_methods/test2.py
+++ b/tests/thread_entry_methods/test2.py
@@ -11,14 +11,14 @@ class Test(Chare):
         self.done_future = done_future
         self.iteration = 0
         for _ in range(NUM_ITER):
-            assert self.thisProxy[self.thisIndex].work(ret=1).get() == 3625
+            assert self.thisProxy[self.thisIndex].work(ret=True).get() == 3625
         self.reduce(self.thisProxy.verify)
 
     @coro
     def work(self):
         if self.iteration % 2 == 0:
             mype = charm.myPe()
-            assert charm.thisProxy[mype].myPe(ret=1).get() == mype
+            assert charm.thisProxy[mype].myPe(ret=True).get() == mype
         self.iteration += 1
         return 3625
 

--- a/tests/when/perf_test.py
+++ b/tests/when/perf_test.py
@@ -38,7 +38,7 @@ def main(args):
     random.shuffle(ids)
 
     done = Future()
-    g.start(done, ret=True).get()
+    g.start(done, awaitable=True).get()
     t0 = time.time()
     for id in ids:
         #g.recv_id(id)


### PR DESCRIPTION
When calling an entry method via a proxy, ret=True means that I
want a return value, regardless of whether it is point-to-point
call or broadcast.

Use awaitable=True if you just want to wait for completion.

Both awaitable=True and ret=True return a future.