### PR TITLE
Rename charm.await() and charm.iawait() to wait() and iwait()

### DIFF
--- a/charm4py/channel.py
+++ b/charm4py/channel.py
@@ -36,7 +36,7 @@ class _Channel(object):
         self.recv_seqno = 0
         self.data = {}
         self.recv_fut = None  # this future is used to block on self.recv()
-        self.wait_ready = None  # this future is used to block on ready (by charm.iawait())
+        self.wait_ready = None  # this future is used to block on ready (by charm.iwait())
         self.established = False
         self.established_fut = None
         self.locally_initiated = locally_initiated

--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -809,7 +809,7 @@ class Charm(object):
 
     # generator that yields objects (works for Futures and Channels) as they
     # become ready (have a msg ready to receive immediately)
-    def iawait(self, objs):
+    def iwait(self, objs):
         n = len(objs)
         f = LocalFuture()
         for obj in objs:
@@ -823,8 +823,8 @@ class Charm(object):
             n -= 1
             yield obj
 
-    def await(self, objs):
-        for o in self.iawait(objs):
+    def wait(self, objs):
+        for o in self.iwait(objs):
             pass
 
     def recordSend(self, size):

--- a/examples/jacobi/jacobi2d.py
+++ b/examples/jacobi/jacobi2d.py
@@ -85,7 +85,7 @@ class Jacobi(Chare):
 
             # receive ghost data from neighbors. iawait iteratively yields
             # channels as they become ready (have data to receive)
-            for nb in charm.iawait(self.nbs):
+            for nb in charm.iwait(self.nbs):
                 direction, ghosts = nb.recv()
                 if direction == LEFT:
                     self.temperature[0, 1:len(ghosts)+1] = ghosts

--- a/examples/multi-module/main.py
+++ b/examples/multi-module/main.py
@@ -16,7 +16,7 @@ class Main(Chare):
         # add mainchare proxy to globals of module goodbye on every process
         future2 = charm.thisProxy.updateGlobals({'mainProxy': self.thisProxy},
                                                 module_name='goodbye', awaitable=True)
-        charm.await((future1, future2))
+        charm.wait((future1, future2))
         # broadcast a message to the hello chares
         hello_chares.SayHi()
 

--- a/examples/particle/particle.py
+++ b/examples/particle/particle.py
@@ -118,7 +118,7 @@ class Cell(Chare):
 
             # receive incoming particles from neighboring cells. iawait iteratively
             # yields channels as they become ready (have data to receive)
-            for channel in charm.iawait(self.neighbors):
+            for channel in charm.iwait(self.neighbors):
                 incoming = channel.recv()
                 self.particles += [Particle(float(incoming[i]),
                                             float(incoming[i+1])) for i in range(0, len(incoming), 2)]

--- a/examples/wave2d/wave2d.py
+++ b/examples/wave2d/wave2d.py
@@ -152,7 +152,7 @@ class Wave(Chare):
 
             # receive ghost values from neighbors. iawait iteratively yields
             # channels as they become ready (have data to receive)
-            for channel in charm.iawait((left, right, bottom, top)):
+            for channel in charm.iwait((left, right, bottom, top)):
                 side, ghost_values = channel.recv()
                 buffers[side] = ghost_values
 

--- a/test_config.json
+++ b/test_config.json
@@ -174,7 +174,7 @@
     },
     {
         "force_min_processes": 4,
-        "path": "tests/futures/iawait.py"
+        "path": "tests/futures/iwait.py"
     },
     {
         "force_min_processes": 4,
@@ -194,7 +194,7 @@
     },
     {
         "force_min_processes": 4,
-        "path": "tests/channels/iawait.py"
+        "path": "tests/channels/iwait.py"
     },
     {
         "force_min_processes": 2,

--- a/tests/channels/iwait.py
+++ b/tests/channels/iwait.py
@@ -23,7 +23,7 @@ class Main(Chare):
 
         t0 = time.time()
         idx = 0
-        for ch in charm.iawait(channels):
+        for ch in charm.iwait(channels):
             assert ch.recv() == idx
             idx += 1
             print(time.time() - t0)

--- a/tests/channels/test2.py
+++ b/tests/channels/test2.py
@@ -32,7 +32,7 @@ class Test(Chare):
             random.shuffle(channels)
             for ch in channels:
                 ch.send(me, start + i)
-            for ch in charm.iawait(channels):
+            for ch in charm.iwait(channels):
                 remote, data = ch.recv()
                 assert data == start + i
                 assert ch.remote == remote

--- a/tests/futures/iwait.py
+++ b/tests/futures/iwait.py
@@ -20,7 +20,7 @@ def main(args):
 
     t0 = time.time()
     idx = 0
-    for f in charm.iawait(futures):
+    for f in charm.iwait(futures):
         assert f.get() == idx
         idx += 1
         print(time.time() - t0)


### PR DESCRIPTION
This is because await is a reserved keyword in Python 3.7