### PR TITLE
Remove LBPeriod from examples using AtSync

### DIFF
--- a/examples/particle/particle.py
+++ b/examples/particle/particle.py
@@ -9,7 +9,7 @@ import sys
 
 # more info about load balancing command-line options here:
 # https://charm.readthedocs.io/en/latest/charm++/manual.html#compiler-and-runtime-options-to-use-load-balancing-module
-sys.argv += ['+LBPeriod', '0.001', '+LBCommOff', '+LBObjOnly']
+sys.argv += ['+LBCommOff', '+LBObjOnly']
 
 NUM_ITER = 100
 SIM_BOX_SIZE = 100.0

--- a/tests/migration/test_nonmigratables.py
+++ b/tests/migration/test_nonmigratables.py
@@ -1,6 +1,6 @@
 from charm4py import charm, Chare, Array
 import sys
-sys.argv += ['+balancer', 'RandCentLB', '+LBPeriod', '0.001']
+sys.argv += ['+balancer', 'RandCentLB']
 
 MAX_ITER = 100
 


### PR DESCRIPTION
The newly merged load balancing patch prohibits using LBPeriod and AtSync simultaneously, so remove the LBPeriod arguments from examples that use AtSync.