### PR TITLE
Allow execution under analysis tools

### DIFF
--- a/auto_test.py
+++ b/auto_test.py
@@ -69,6 +69,8 @@ for test in tests:
             if num_tests >= CHARM_QUIET_AFTER_NUM_TESTS and '++quiet' not in commonArgs:
                 additionalArgs.append('++quiet')
             cmd = ['charmrun/charmrun']
+            if test.get('prefix'):
+                cmd += [test['prefix']]
             if not test.get('interactive', False):
                 cmd += [python] + [test['path']]
             else:

--- a/charmrun/start.py
+++ b/charmrun/start.py
@@ -3,6 +3,17 @@ import os
 import os.path
 
 
+def executable_is_python(args):
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+    for each in args:
+        if is_exe(each):
+            return each.endswith(".py")
+    # Either a python file is provided without execution permissions,
+    # or no executable was found and we let Python tell us
+    return True
+
+
 def nodelist_islocal(filename, regexp):
     if not os.path.exists(filename):
         # it is an error if filename doesn't exist, but I'll let charmrun print
@@ -53,7 +64,8 @@ def start(args=[]):
         args += ['-m', 'charm4py.interactive']
 
     cmd = [os.path.join(os.path.dirname(__file__), 'charmrun')]
-    cmd.append(sys.executable)  # for example: /usr/bin/python3
+    if executable_is_python(args):
+        cmd.append(sys.executable)  # for example: /usr/bin/python3
     cmd.extend(args)
     try:
         return subprocess.call(cmd)

--- a/charmrun/start.py
+++ b/charmrun/start.py
@@ -18,11 +18,10 @@ def executable_is_python(args):
     def is_pyfile(fpath):
         return os.path.isfile(fpath) and fpath.endswith(".py")
     for each in args:
-        if is_exe(each):
-            return is_pyfile(each)
-        # Python file, but execution bit is not set.
         if is_pyfile(each):
             return True
+        if is_exe(each):
+            return False
     # No executable was found, but we'll let Python tell us
     return True
 

--- a/charmrun/start.py
+++ b/charmrun/start.py
@@ -14,11 +14,16 @@ def executable_is_python(args):
     """
     def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    def is_pyfile(fpath):
+        return os.path.isfile(fpath) and fpath.endswith(".py")
     for each in args:
         if is_exe(each):
-            return each.endswith(".py")
-    # Either a python file is provided without execution permissions,
-    # or no executable was found and we let Python tell us
+            return is_pyfile(each)
+        # Python file, but execution bit is not set.
+        if is_pyfile(each):
+            return True
+    # No executable was found, but we'll let Python tell us
     return True
 
 

--- a/charmrun/start.py
+++ b/charmrun/start.py
@@ -4,6 +4,14 @@ import os.path
 
 
 def executable_is_python(args):
+    """
+    Determines whether the first executable passed to args is a
+    Python file. Other valid examples include analysis tools
+    such as Perf that will run the actual Python program.
+
+    Note: Returns true if no executable was found or if an executable
+    was found and that executable is a Python file.
+    """
     def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
     for each in args:
@@ -65,6 +73,9 @@ def start(args=[]):
 
     cmd = [os.path.join(os.path.dirname(__file__), 'charmrun')]
     if executable_is_python(args):
+        # Note: sys.executable is the absolute path to the Python interpreter
+        # We only want to invoke the interpreter if the execution target is a
+        # Python file
         cmd.append(sys.executable)  # for example: /usr/bin/python3
     cmd.extend(args)
     try:

--- a/test_config.json
+++ b/test_config.json
@@ -289,6 +289,10 @@
         "path": "examples/simple/hello_world.py"
     },
     {
+        "prefix": "tests/exec.sh",
+        "path": "examples/simple/hello_world.py"
+    },
+    {
         "condition": "numbaInstalled",
         "path": "examples/wave2d/wave2d.py",
         "args": "300 -1 --NO-RENDER"

--- a/tests/exec.sh
+++ b/tests/exec.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Just execute the given command
+"$@"


### PR DESCRIPTION
Fixes #206. Performance analysis and memory debugging tools such as Perf and Valgrind do not currently work with Charm4Py's ```charmrun.start```. This patch enables the use of ```charmrun.start``` with these tools.
