### PR TITLE
Optimize metadata packing for Numpy arrays of 'builtin' types

### DIFF
--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -381,7 +381,10 @@ class Charm(object):
                         # memoryview, Python throws error: "memoryview: underlying buffer is not
                         # C-contiguous", which seems to be a CPython error (not cffi related)
                         nbytes = arg.nbytes
-                        direct_copy_hdr.append((i, 2, (arg.shape, arg.dtype.name), nbytes))
+                        if arg.dtype.isbuiltin:
+                            direct_copy_hdr.append((i, 2, (arg.shape, arg.dtype.char), nbytes))
+                        else:
+                            direct_copy_hdr.append((i, 2, (arg.shape, arg.dtype.name), nbytes))
                     else:
                         continue
                     args[i] = None  # will direct-copy this arg so remove from args list

--- a/charm4py/charmlib/charmlib_cython.pyx
+++ b/charm4py/charmlib/charmlib_cython.pyx
@@ -791,7 +791,10 @@ class CharmLib(object):
         if isinstance(arg, np.ndarray) and not arg.dtype.hasobject:
           np_array = arg
           nbytes = np_array.nbytes
-          direct_copy_hdr.append((i, 2, (arg.shape, np_array.dtype.name), nbytes))
+          if arg.dtype.isbuiltin:
+            direct_copy_hdr.append((i, 2, (arg.shape, arg.dtype.char), nbytes))
+          else:
+            direct_copy_hdr.append((i, 2, (arg.shape, arg.dtype.name), nbytes))
           send_bufs[cur_buf] = <char*>np_array.data
         elif isinstance(arg, bytes):
           nbytes = len(arg)


### PR DESCRIPTION
When sending messages that contain numpy arrays of built-in types, it is faster to access ```array.dtype.char``` than it is to access ```array.dtype.name```.  More information about datatypes in numpy can be found [here](https://numpy.org/doc/stable/reference/arrays.dtypes.html#data-type-objects-dtype). This patch adds a check for whether a numpy array contains a built-in type, and if so uses the faster method to obtain the type information. This patch decreases message latency almost 12us (from 35.9us to 24.1us) in a microbenchmark. 

This method of accessing the data type is faster because ```array.dtype.name``` executes additional Python code as it has to access arbitrary Python strings (in the case where custom types are created/used).