### PR TITLE
WIP: Add 'expedited' decorator for urgent messages

### DIFF
--- a/charm4py/__init__.py
+++ b/charm4py/__init__.py
@@ -26,7 +26,7 @@ if os.environ.get('CHARM_NOLOAD', '0') == '0':
     Reducer = charm.reducers
     Future = charm.createFuture
 
-    from .entry_method import when, coro, coro_ext, coro as threaded
+    from .entry_method import when, coro, coro_ext, coro as threaded, expedited
 
     from .chare import Chare, Group, Array, ArrayMap
     from .channel import Channel

--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -120,6 +120,7 @@ class Charm(object):
         self.CkChareSend = self.lib.CkChareSend
         self.CkGroupSend = self.lib.CkGroupSend
         self.CkArraySend = self.lib.CkArraySend
+        self.em_options = self.lib.em_options
         self.reducers = reduction.ReducerContainer(self)
         self.redMgr = reduction.ReductionManager(self, self.reducers)
         self.mainchareRegistered = False

--- a/charm4py/charmlib/ccharm.pxd
+++ b/charm4py/charmlib/ccharm.pxd
@@ -38,8 +38,8 @@ cdef extern from "charm.h":
     void CkChareExtSend_multi(int onPE, void *objPtr, int epIdx, int num_bufs, char **bufs, int *buf_sizes);
     void CkGroupExtSend(int gid, int npes, int *pes, int epIdx, char *msg, int msgSize);
     void CkGroupExtSend_multi(int gid, int npes, int *pes, int epIdx, int num_bufs, char **bufs, int *buf_sizes);
-    void CkArrayExtSend(int aid, int *idx, int ndims, int epIdx, char *msg, int msgSize);
-    void CkArrayExtSend_multi(int aid, int *idx, int ndims, int epIdx, int num_bufs, char **bufs, int *buf_sizes);
+    void CkArrayExtSend(int aid, int *idx, int ndims, int epIdx, char *msg, int msgSize, int opts);
+    void CkArrayExtSend_multi(int aid, int *idx, int ndims, int epIdx, int num_bufs, char **bufs, int *buf_sizes, int opts);
     void CkForwardMulticastMsg(int gid, int num_children, int *children);
 
     int CkGroupGetReductionNumber(int gid);
@@ -69,7 +69,6 @@ cdef extern from "charm.h":
     void CkStartQDExt_ArrayCallback(int aid, int* idx, int ndims, int epIdx, int fid);
     void CkStartQDExt_SectionCallback(int sid_pe, int sid_cnt, int rootPE, int ep);
     void CcdCallFnAfter(void (*CcdVoidFn)(void *userParam,double curWallTime), void *arg, double msecs);
-
 
 cdef extern from "spanningTree.h":
     void getPETopoTreeEdges(int pe, int rootPE, int *pes, int numpes, unsigned int bfactor,

--- a/charm4py/entry_method.py
+++ b/charm4py/entry_method.py
@@ -2,7 +2,15 @@ from . import wait
 from time import time
 import sys
 from greenlet import greenlet, getcurrent
+from . import charm
 
+class EntryMethodOptions:
+    def __init__(self):
+        self.value = 0
+    def set_option(self, val_identifier):
+        self.value |= val_identifier
+    def get(self):
+        return self.value
 
 class EntryMethod(object):
 
@@ -27,6 +35,10 @@ class EntryMethod(object):
                 self.run = self._run
             else:
                 self.run = self._run_prof
+
+        self._msg_opts = None
+        if hasattr(method, '_msg_opts'):
+            self._msg_opts = method._msg_opts
 
         self.when_cond = None
         if hasattr(method, 'when_cond'):
@@ -174,6 +186,14 @@ def when(cond_str):
 
 def coro(func):
     func._ck_coro = True
+    return func
+
+def expedited(func):
+    options = EntryMethodOptions()
+    # TODO: get this value from charm
+    # options.set_value(charm.em_options.CK_EXPEDITED)
+    options.set_option(0x4)
+    func._msg_opts = options
     return func
 
 


### PR DESCRIPTION
This patch adds the ```@expedited``` decorator to enable urgent inter-PE messages to skip the message queue. This patch also lays the groundwork for adding additional entry method options such as priorities.

Example of usage:
```python
from charm4py import charm, Chare, Array, expedited


class Test(Chare):
    """
    A chare array to test the element proxy.
    """

    def __init__(self):
        self.count = 0

    @expedited
    def say(self, msg):
        """
        Helper method which is called by invoking the element proxy.
        This method is expected to be called on only the chare for
        which the proxy is created.
        """

        self.count += 1
        print("Say", msg, "called on", self.thisIndex, "on PE", charm.myPe())
        if self.count == 2:
            assert self.thisIndex == (3,)
            exit()

    def start(self):
        proxy = self.thisProxy[3]
        proxy.say("bye")
        proxy.say("bye")


def main(args):
    arr_proxy = Array(Test, 6)
    arr_proxy[0].start()


charm.start(main)
```