### PR TITLE
Build Charm4Py with UCX and SlurmPMI on SDSC Expanse

### DIFF
--- a/charm4py/charm.py
+++ b/charm4py/charm.py
@@ -28,6 +28,7 @@ from .threads import Future, LocalFuture
 from . import reduction
 from . import wait
 import array
+sys.setdlopenflags(os.RTLD_NOW | os.RTLD_GLOBAL)
 try:
     import numpy
 except ImportError:
@@ -106,11 +107,11 @@ class Charm(object):
         self.options.interactive.verbose = 1
         self.options.interactive.broadcast_imports = True
 
-        if 'OMPI_COMM_WORLD_SIZE' in os.environ:
-            # this is needed for OpenMPI, see:
-            # https://svn.open-mpi.org/trac/ompi/wiki/Linkers
-            import ctypes
-            self.__libmpi__ = ctypes.CDLL('libmpi.so', mode=ctypes.RTLD_GLOBAL)
+        #if 'OMPI_COMM_WORLD_SIZE' in os.environ:
+        #    # this is needed for OpenMPI, see:
+        #    # https://svn.open-mpi.org/trac/ompi/wiki/Linkers
+        #    import ctypes
+        #    self.__libmpi__ = ctypes.CDLL('libmpi.so', mode=ctypes.RTLD_GLOBAL)
         self.lib = load_charm_library(self)
         self.ReducerType = self.lib.ReducerType
         self.CkContributeToChare = self.lib.CkContributeToChare


### PR DESCRIPTION
### Experimental setup (SDSC Expanse)

1.  Install Miniconda, install packages
```bash
    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
    chmod +x ./Miniconda3-latest-Linux-x86_64.sh 
    ./Miniconda3-latest-Linux-x86_64.sh 
    conda create --name charm4py
    conda activate charm4py
    conda install --yes numpy scipy pandas greenlet cython
```
2.  Install UCX
```bash
    git clone https://github.com/openucx/ucx.git
    # Version 1.10.1
    git checkout 6a5856ef4f72c8139951e7ed1d0a4cb75a2e82ec
    mkdir ~/.local
    cd ucx/
    module load gcc/10.2.0
    # This was required because UCX wasn't finding the NUMA libraries. 
    # This command should work directly on Expanse (from [[https://github.com/openucx/ucx/issues/4774#issuecomment-586646345][here]])
    export NUMA_HOME=/cm/shared/apps/spack/cpu/opt/spack/linux-centos8-zen/gcc-8.3.1/numactl-2.0.12-uvjxkgifpcwra25lv6tzxa5gof5ayfkq
    CFLAGS="-I$NUMA_HOME/include"
    LDFLAGS="-L$NUMA_HOME/lib -Wl,-rpath,$NUMA_HOME/lib"
    export CFLAGS LDFLAGS
    ../contrib/configure-release --prefix=$HOME/.local/ucx
    make -j && make install
```

3.  Install Charm++
```bash
    cd ~
    mkdir charms
    cd charms
    git clone https://github.com/UIUC-PPL/charm.git
    cd charm
    git checkout charm4py_expanse
    ./build charm++ ucx-linux-x86_64 slurmpmi --with-production --basedir=$HOME/.local/ucx -j --force
```

4.  Install Charm4Py
   ``` bash
    cd ~/charms
    git clone https://github.com/UIUC-PPL/charm4py.git
    cd charm4py
    git checkout expanse
    # The paths containing UCX libraries, Slurm, and PMI should be on your LD_LIBRARY_PATH.
    # You will need to add the UCX libraries yourself, but on expanse Slurm and PMI should be there
    # to begin with.
    python3 -m pip install --user -e .
```