### PR TITLE
Add concurrent.futures.Executor implementation

### DIFF
--- a/charm4py/pool.py
+++ b/charm4py/pool.py
@@ -471,8 +471,8 @@ class Pool(object):
 
 class PoolExecutor(Executor):
 
-    def __init__(self, pool_scheduler):
-        self.pool = Pool(pool_scheduler)
+    def __init__(self, pool_scheduler_chare):
+        self.pool = Pool(pool_scheduler_chare)
         self.is_shutdown = False
 
     def submit(self, fn, /, *args, **kwargs):
@@ -486,8 +486,9 @@ class PoolExecutor(Executor):
         return wait_for(self.pool.map(func, zip(*iterables), chunksize=chunksize, ncores=ncores), timeout=timeout)
 
     def shutdown(wait=True, *, cancel_futures=False):
-        # Cancelling futures isn't implemented so 
-        # cancel_futures currently does nothing
+        if cancel_futures == True:
+            raise NotImplementedError("Cancelling futures on shutdown not currently supported")
+    
         self.is_shutdown = True
         if wait:
             wait_for(self.pool.pool_scheduler.schedule())

--- a/charm4py/pool.py
+++ b/charm4py/pool.py
@@ -488,6 +488,7 @@ class PoolExecutor(Executor):
     def shutdown(wait=True, *, cancel_futures=False):
         # Cancelling futures isn't implemented so 
         # cancel_futures currently does nothing
+        self.is_shutdown = True
         if wait:
             wait_for(self.pool.pool_scheduler.schedule())
         else:

--- a/charm4py/pool.py
+++ b/charm4py/pool.py
@@ -475,10 +475,15 @@ class PoolExecutor(Executor):
         self.pool = Pool(pool_scheduler_chare)
         self.is_shutdown = False
 
-    def submit(self, fn, /, *args, **kwargs):
+    # map_async can't handle **kwargs at present
+    def submit(self, fn, /, *args, **kwargs)#, chunksize=1, ncores=-1, multi_future=False):
         if self.is_shutdown:
             raise RuntimeError("charm4py.pool.PoolExecutor object has been shut down")
-        return self.pool.Task(fn, *args, **kwargs, awaitable=True, ret=True)        
+        if kwargs is not None and len(kwargs > 0):
+            raise NotImplementedError("kwargs for PoolExecutor.submit are not supported currently")            
+
+        return self.pool.Task(fn, args, ret=True)        
+        #return self.pool.map_async(fn, args, chunksize=chunksize, ncores=ncores, multi_future=multi_future)
 
     def map(self, func, *iterables, timeout=None, chunksize=1, ncores=-1):
         if self.is_shutdown:

--- a/charm4py/threads.py
+++ b/charm4py/threads.py
@@ -36,6 +36,7 @@ class Future(CFuture):
         self.blocked = False  # flag to check if creator thread is blocked on the future
         self.gotvalues = False  # flag to check if expected number of values have been received
         self.error = None  # if the future receives an Exception, it is set here
+        self.cancelled = False
 
     def get(self):
         """ Blocking call on current entry method's thread to obtain the values of the
@@ -103,12 +104,13 @@ class Future(CFuture):
             return True
 
     def cancelled(self):
-        return self.values == [None] * f.nvals
+        # What if function actually returns this?
+        #return self.values == [None] * f.nvals
+        return self.cancelled
 
     def running(self):
-        # Not certain how to check if the future is currently running.
-        return not self.done()
-        #return not self.blocked and not self.ready()
+        # Not certain if this is correct
+        return self.blocked != False and not self.done()
     
     def done(self):
         return self.ready()
@@ -291,6 +293,7 @@ class EntryMethodThreadManager(object):
         del self.futures[fid]
         f.gotvalues = True
         f.values = [None] * f.nvals
+        f.cancelled = True
         f.resume(self)
 
     # TODO: method to cancel collective future. the main issue with this is

--- a/charm4py/threads.py
+++ b/charm4py/threads.py
@@ -103,7 +103,7 @@ class Future(CFuture):
             return True
 
     def cancelled(self):
-        return self.values == [None] * f.nvals:
+        return self.values == [None] * f.nvals
 
     def running(self):
         # Not certain how to check if the future is currently running.

--- a/charm4py/threads.py
+++ b/charm4py/threads.py
@@ -96,14 +96,19 @@ class Future(CFuture):
         self.fid, self.src = state
 
     def cancel(self):
-        # Cancelling not currently implemented
-        return False
+        if self.running() or self.done():
+            return False
+        else:
+            threadMgr.cancelFuture(self)            
+            return True
 
     def cancelled(self):
-        return False
+        return self.values == [None] * f.nvals:
 
     def running(self):
-        return not self.blocked and not self.ready()
+        # Not certain how to check if the future is currently running.
+        return not self.done()
+        #return not self.blocked and not self.ready()
     
     def done(self):
         return self.ready()


### PR DESCRIPTION
This adds most of a [concurrent.futures.Executor](https://docs.python.org/3/library/concurrent.futures.html) implementation for Charm4py so Charm4py can be dropped in wherever `ThreadPoolExecutor`, `ProcessPoolExecutor`, `MPI4pyPoolExecutor`, etc. is used.

A `PoolExecutor` class in `pool.py` implements the `Executor` API by calling to equivalent `Pool` methods. This pull request also makes `charm4py.threads.Future` inherit from `concurrent.futures.Future` and implements its API.

Functionality not currently implemented
* `Executor.add_done_callback` 
* Correct handling of `timeout` argument in `Executor.map`, `Future.result` and `Future.exception`
* Correct handling of `wait`and `cancel_futures` kwargs in `Executor.shutdown` 

TODO:
- [ ] Update dependencies
- [ ] Update documentation
- [ ] Add tests