### PR TITLE
Use native bool type in arrays instead of deprecated np.bool

### DIFF
--- a/tests/reductions/logical_ops.py
+++ b/tests/reductions/logical_ops.py
@@ -9,7 +9,7 @@ class Test(Chare):
 
     def doallfalse(self, f1, f2, f3, array=False):
         if array:
-            data = np.zeros(ARRAY_SIZE, dtype=np.bool)
+            data = np.zeros(ARRAY_SIZE, dtype=bool)
         else:
             data = False
         self.reduce(f1, data, Reducer.logical_and)
@@ -18,7 +18,7 @@ class Test(Chare):
 
     def doalltrue(self, f1, f2, f3, array=False):
         if array:
-            data = np.ones(ARRAY_SIZE, dtype=np.bool)
+            data = np.ones(ARRAY_SIZE, dtype=bool)
         else:
             data = True
         self.reduce(f1, data, Reducer.logical_and)
@@ -43,9 +43,9 @@ def main(args):
 
     f1, f2, f3 = Future(), Future(), Future()
     g.doallfalse(f1, f2, f3, array=True)
-    np.testing.assert_array_equal(f1.get(), np.zeros(ARRAY_SIZE, dtype=np.bool))
-    np.testing.assert_array_equal(f2.get(), np.zeros(ARRAY_SIZE, dtype=np.bool))
-    np.testing.assert_array_equal(f3.get(), np.zeros(ARRAY_SIZE, dtype=np.bool))
+    np.testing.assert_array_equal(f1.get(), np.zeros(ARRAY_SIZE, dtype=bool))
+    np.testing.assert_array_equal(f2.get(), np.zeros(ARRAY_SIZE, dtype=bool))
+    np.testing.assert_array_equal(f3.get(), np.zeros(ARRAY_SIZE, dtype=bool))
 
     f1, f2, f3 = Future(), Future(), Future()
     g.doalltrue(f1, f2, f3, array=False)
@@ -55,9 +55,9 @@ def main(args):
 
     f1, f2, f3 = Future(), Future(), Future()
     g.doalltrue(f1, f2, f3, array=True)
-    np.testing.assert_array_equal(f1.get(), np.ones(ARRAY_SIZE, dtype=np.bool))
-    np.testing.assert_array_equal(f2.get(), np.ones(ARRAY_SIZE, dtype=np.bool))
-    np.testing.assert_array_equal(f3.get(), np.zeros(ARRAY_SIZE, dtype=np.bool))
+    np.testing.assert_array_equal(f1.get(), np.ones(ARRAY_SIZE, dtype=bool))
+    np.testing.assert_array_equal(f2.get(), np.ones(ARRAY_SIZE, dtype=bool))
+    np.testing.assert_array_equal(f3.get(), np.zeros(ARRAY_SIZE, dtype=bool))
 
     f1, f2, f3 = Future(), Future(), Future()
     g.test1(f1, f2, f3)


### PR DESCRIPTION
The numpy datatype `np.bool` was deprecated in [NumPy 1.20](https://numpy.org/doc/stable/release/1.20.0-notes.html). This now causes unrelated Charm4Py build failures in Charm CI. This PR fixes the issue.