### PR TITLE
Fix build for ARM-based Machines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,17 +13,17 @@ import distutils
 
 
 build_mpi = False
-system = platform.system()
-machine = platform.machine()
 
 
-def get_build_machine(machine):
+def get_build_machine():
+    machine = platform.machine()
     if machine == 'arm64' or machine == 'aarch64':
         return 'arm8'
     return machine
 
 
-def get_build_os(os):
+def get_build_os():
+    os = platform.system()
     return os.lower()
 
 
@@ -32,8 +32,8 @@ def get_build_network_type(build_mpi):
 
 
 def get_build_triple(machine, os, build_mpi):
-    return (get_build_machine(machine),
-            get_build_os(os),
+    return (get_build_machine(),
+            get_build_os(),
             get_build_network_type(build_mpi)
             )
 

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,8 @@ machine = platform.machine()
 
 
 def get_build_machine(machine):
-    if machine.startswith('arm'):
-        import re
-        regexp = re.compile("arm(\d+).*")
-        m = regexp.match(machine)
-        if m:
-            version = int(m.group(1))
-            if version < 8:
-                return 'arm7'
-            else:
-                return 'arm8'
+    if machine == 'arm64' or machine == 'aarch64':
+        return 'arm8'
     return machine
 
 


### PR DESCRIPTION
The automatic build for Charm++ did not work for ARM-based machines, including the new Macs. This fixes the error.